### PR TITLE
chore: raise coverage thresholds to 80/90/85

### DIFF
--- a/denvault-extension/vitest.config.ts
+++ b/denvault-extension/vitest.config.ts
@@ -19,9 +19,9 @@ export default defineConfig({
         "**/*.spec.ts",
       ],
       thresholds: {
-        branches: 55,
-        functions: 68,
-        lines: 60,
+        branches: 80,
+        functions: 90,
+        lines: 85,
       },
     },
     setupFiles: ["./src/test/setup.ts"],


### PR DESCRIPTION
## Summary

- Raise vitest coverage thresholds from 55/68/60 to **80/90/85** (branches/functions/lines)
- Current coverage exceeds all thresholds: 84.48/95.85/93.14

## Test plan
- [x] `pnpm test:coverage` passes with new thresholds

Wolfcito 🐾 @akawolfcito