### PR TITLE
test(e2e): send STX flow + shared helpers (#11 PR A)

### DIFF
--- a/denvault-extension/e2e/helpers/network-mocks.ts
+++ b/denvault-extension/e2e/helpers/network-mocks.ts
@@ -1,0 +1,133 @@
+import type { Page, Route } from "@playwright/test";
+
+/**
+ * Network mocks for Stacks E2E flows.
+ *
+ * Critical: every endpoint that could touch a remote node must be intercepted.
+ * If a real broadcast or balance fetch escapes, the wallet flows would either
+ * hit live infrastructure or fail in non-deterministic ways. The default
+ * handlers below answer with a fully self-contained dataset.
+ */
+
+export interface MockOptions {
+  /** STX balance in microSTX. Defaults to 1000 STX (1_000_000_000 µSTX). */
+  balanceMicroStx?: string;
+  /** Account nonce. Defaults to 0. */
+  nonce?: number;
+  /** Hex transaction id returned on successful broadcast. */
+  txid?: string;
+  /** Force broadcast to fail with this reason (string passes to JSON body). */
+  broadcastError?: { reason: string; reasonData?: unknown };
+}
+
+const DEFAULTS: Required<Pick<MockOptions, "balanceMicroStx" | "nonce" | "txid">> = {
+  balanceMicroStx: "1000000000",
+  nonce: 0,
+  txid: "a".repeat(64),
+};
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function fulfillText(route: Route, body: string, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "text/plain",
+    body,
+  });
+}
+
+/**
+ * Install Hiro/Stacks API mocks on the page. Routes are matched by URL path
+ * fragments so we don't need to enumerate every host (mainnet/testnet/devnet/
+ * platform proxy). Returns an unmock helper if the caller wants to remove
+ * them mid-test.
+ */
+export async function mockStacksNetwork(
+  page: Page,
+  options: MockOptions = {},
+): Promise<() => Promise<void>> {
+  const balanceMicroStx = options.balanceMicroStx ?? DEFAULTS.balanceMicroStx;
+  const nonce = options.nonce ?? DEFAULTS.nonce;
+  const txid = options.txid ?? DEFAULTS.txid;
+
+  // Address balances (extended API).
+  await page.route("**/extended/v1/address/*/balances", (route) =>
+    fulfillJson(route, {
+      stx: { balance: balanceMicroStx, total_sent: "0", total_received: balanceMicroStx },
+      fungible_tokens: {},
+      non_fungible_tokens: {},
+    }),
+  );
+
+  // Account info / nonce (core API).
+  await page.route("**/v2/accounts/*", (route) =>
+    fulfillJson(route, {
+      balance: `0x${BigInt(balanceMicroStx).toString(16)}`,
+      locked: "0x0",
+      unlock_height: 0,
+      nonce,
+      balance_proof: "",
+      nonce_proof: "",
+    }),
+  );
+
+  // Fee estimate.
+  await page.route("**/v2/fees/transaction", (route) =>
+    fulfillJson(route, {
+      cost_scalar_change_by_byte: 0,
+      estimated_cost: { read_count: 0, read_length: 0, runtime: 0, write_count: 0, write_length: 0 },
+      estimated_cost_scalar: 0,
+      estimations: [
+        { fee: 180, fee_rate: 1 },
+        { fee: 250, fee_rate: 1 },
+        { fee: 380, fee_rate: 1 },
+      ],
+    }),
+  );
+
+  // Broadcast endpoint.
+  await page.route("**/v2/transactions", async (route) => {
+    if (options.broadcastError) {
+      await fulfillJson(route, { error: "Broadcast failed", reason: options.broadcastError.reason, reason_data: options.broadcastError.reasonData ?? null }, 400);
+      return;
+    }
+    // Stacks broadcast endpoint returns the txid as a quoted hex string.
+    await fulfillText(route, `"${txid}"`);
+  });
+
+  // Tx status (used by some views to poll). Always say pending so we don't
+  // depend on chain state.
+  await page.route("**/extended/v1/tx/*", (route) =>
+    fulfillJson(route, {
+      tx_id: `0x${txid}`,
+      tx_status: "pending",
+      tx_type: "token_transfer",
+    }),
+  );
+
+  return async () => {
+    await page.unroute("**/extended/v1/address/*/balances");
+    await page.unroute("**/v2/accounts/*");
+    await page.unroute("**/v2/fees/transaction");
+    await page.unroute("**/v2/transactions");
+    await page.unroute("**/extended/v1/tx/*");
+  };
+}
+
+/**
+ * Fail the test if any non-mocked Stacks API call leaks through. Call AFTER
+ * `mockStacksNetwork` to install a guard that rejects unexpected hosts.
+ */
+export async function blockUnmockedStacksHosts(page: Page): Promise<void> {
+  await page.route(/api(\.[a-z-]+)?\.hiro\.so|stacks-node|api\.platform\.hiro\.so/, async (route) => {
+    const url = route.request().url();
+    await route.abort();
+    throw new Error(`Unmocked Stacks API call escaped to: ${url}`);
+  });
+}

--- a/denvault-extension/e2e/helpers/storage.ts
+++ b/denvault-extension/e2e/helpers/storage.ts
@@ -1,0 +1,37 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Clear in-page storage layers used by DenVault.
+ *
+ * The Vite dev server has no `chrome.storage` API, so the WalletVault falls
+ * back to `localStorage`. We try both to keep the helper safe against future
+ * environments where chrome.storage is shimmed.
+ */
+export async function clearStorage(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    localStorage.clear();
+    type ChromeLike = {
+      storage?: { local?: { clear?: () => Promise<void> } };
+    };
+    const maybeChrome = (globalThis as unknown as { chrome?: ChromeLike })
+      .chrome;
+    if (maybeChrome?.storage?.local?.clear) {
+      try {
+        await maybeChrome.storage.local.clear();
+      } catch {
+        // localStorage fallback is sufficient for the dev server.
+      }
+    }
+  });
+}
+
+/**
+ * Navigate to a hash-based route after clearing storage and reloading.
+ * Default route is `/` (StartView).
+ */
+export async function gotoFresh(page: Page, route = "/"): Promise<void> {
+  await page.goto(route);
+  await clearStorage(page);
+  await page.reload();
+  await page.waitForLoadState("networkidle");
+}

--- a/denvault-extension/e2e/helpers/wallet-setup.ts
+++ b/denvault-extension/e2e/helpers/wallet-setup.ts
@@ -1,0 +1,121 @@
+import { expect, type Page } from "@playwright/test";
+import { TEST_MNEMONIC, TEST_PIN } from "../fixtures/mock-wallet";
+
+/**
+ * Reusable interactions for DenVault wallet flows in E2E specs.
+ * Mirrors the canonical paths validated by `wallet-flows.spec.ts` (issue #10).
+ */
+
+export { TEST_MNEMONIC, TEST_PIN };
+
+export async function revealAndReadMnemonic(page: Page): Promise<string[]> {
+  const reveal = page.locator('[data-roi="reveal-btn"]');
+  await reveal.waitFor({ state: "visible" });
+  await reveal.click();
+  const grid = page.locator('[data-roi="mnemonic-grid"]');
+  await expect(grid).not.toHaveClass(/mnemonic-grid--hidden/);
+  const wordTexts = await grid.locator(".word-text").allInnerTexts();
+  return wordTexts.map((w) => w.trim()).filter((w) => w.length > 0);
+}
+
+export async function extractVerifyOrdinals(
+  page: Page,
+): Promise<[number, number]> {
+  const subtitle = await page
+    .locator('[data-roi="verify-subtitle"]')
+    .innerText();
+  const matches = [...subtitle.matchAll(/(\d+)(st|nd|rd|th)/gi)];
+  if (matches.length < 2) {
+    throw new Error(
+      `Expected 2 ordinals in verify subtitle, got: "${subtitle}"`,
+    );
+  }
+  return [
+    parseInt(matches[0][1], 10) - 1,
+    parseInt(matches[1][1], 10) - 1,
+  ];
+}
+
+export async function fillVerifyWords(
+  page: Page,
+  mnemonicWords: string[],
+): Promise<void> {
+  const [i1, i2] = await extractVerifyOrdinals(page);
+
+  const w1 = page.locator('[data-roi="verify-word-1-input"]');
+  await w1.click();
+  await w1.fill("");
+  await page.keyboard.type(mnemonicWords[i1], { delay: 10 });
+  // Close the typeahead dropdown so it does not intercept the next click.
+  await page.keyboard.press("Escape");
+
+  const w2 = page.locator('[data-roi="verify-word-2-input"]');
+  await w2.click();
+  await w2.fill("");
+  await page.keyboard.type(mnemonicWords[i2], { delay: 10 });
+  await page.keyboard.press("Escape");
+}
+
+export async function enterPin(page: Page, pin: string): Promise<void> {
+  const container = page.locator('[data-roi="pin-input"]').first();
+  await container.waitFor({ state: "visible" });
+  await container.focus();
+  for (const digit of pin) {
+    await page.keyboard.press(digit);
+  }
+}
+
+export async function completePinSetup(
+  page: Page,
+  pin: string,
+): Promise<void> {
+  await enterPin(page, pin);
+  await expect(page.locator('[data-roi="pin-input"]')).toBeVisible();
+  await enterPin(page, pin);
+}
+
+export async function submitWrongPinThreeTimes(page: Page): Promise<void> {
+  const wrongPin = "000000";
+  const errorSlot = page.locator('[data-roi="pin-error-slot"]');
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    await enterPin(page, wrongPin);
+    await expect(errorSlot).toContainText(/Wrong PIN/i, { timeout: 5_000 });
+    await expect(
+      page.locator('[data-roi="pin-dots-rail"] .pin-dot--filled'),
+    ).toHaveCount(0);
+  }
+
+  await enterPin(page, wrongPin);
+}
+
+/**
+ * Drive the import flow end-to-end with TEST_MNEMONIC + TEST_PIN.
+ * Leaves the page on `/#/user`.
+ */
+export async function importTestWalletThroughUi(page: Page): Promise<void> {
+  await page.locator('[data-roi="start-secondary-cta"]').click();
+  await expect(
+    page.locator('[data-roi="import-recovery-screen"]'),
+  ).toBeVisible();
+
+  const textarea = page
+    .locator('[data-roi="import-mnemonic-input"] textarea')
+    .first();
+  await textarea.click();
+  await textarea.fill(TEST_MNEMONIC);
+
+  await expect(page.locator('[data-roi="import-cta-primary"]')).toBeEnabled();
+  await page.locator('[data-roi="import-cta-primary"]').click();
+
+  await expect(page.locator('[data-roi="mnemonic-step"]')).toBeVisible();
+  const words = await revealAndReadMnemonic(page);
+
+  await page.locator('[data-roi="cta-primary"]').click();
+  await expect(page.locator('[data-roi="verify-phrase-step"]')).toBeVisible();
+  await fillVerifyWords(page, words);
+  await page.locator('[data-roi="verify-cta-primary"]').click();
+
+  await completePinSetup(page, TEST_PIN);
+  await expect(page).toHaveURL(/#\/user/, { timeout: 10_000 });
+}

--- a/denvault-extension/e2e/send-flow.spec.ts
+++ b/denvault-extension/e2e/send-flow.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type Page } from "@playwright/test";
+import { gotoFresh } from "./helpers/storage";
+import { mockStacksNetwork } from "./helpers/network-mocks";
+import {
+  TEST_PIN,
+  enterPin,
+  importTestWalletThroughUi,
+} from "./helpers/wallet-setup";
+
+/**
+ * Interactive E2E for the Send STX flow (issue #11).
+ *
+ * All Stacks API endpoints are intercepted; no real broadcast or balance
+ * fetch escapes the test boundary. The flow walks SendView → ConfirmTxView
+ * → SendView (PIN step) → TxResultView with a mocked txid.
+ */
+
+// Valid testnet/devnet (ST*) STX address used for the recipient field.
+const VALID_RECIPIENT = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+// 1000 STX in microSTX. Matches the default mock balance and the
+// formatStxDisplay output (no thousands separator at this magnitude).
+const MOCKED_BALANCE_DISPLAY = "Available: 1000 STX";
+const MOCKED_TXID = "a".repeat(64);
+
+async function navigateToSendForm(page: Page) {
+  // Avoid clicking through the home ActionBar: the Send action button has no
+  // data-roi yet, so we navigate directly via the hash route. SendView's
+  // onBeforeMount will redirect to /unlock if the wallet is locked.
+  await page.goto("/#/send");
+  await expect(page.locator('[data-roi="send-screen"]')).toBeVisible();
+  await expect(page.locator('[data-roi="send-form"]')).toBeVisible();
+}
+
+async function fillSendForm(
+  page: Page,
+  opts: { recipient: string; amount: string },
+) {
+  const recipient = page
+    .locator('[data-roi="send-textfield-to"] input')
+    .first();
+  await recipient.click();
+  await recipient.fill(opts.recipient);
+  // Trigger validation via blur.
+  await recipient.blur();
+
+  const amount = page
+    .locator('[data-roi="send-textfield-amount"] input')
+    .first();
+  await amount.click();
+  await amount.fill(opts.amount);
+  await amount.blur();
+}
+
+test.describe.serial("DenVault send STX flow (issue #11)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockStacksNetwork(page);
+    await gotoFresh(page);
+    await importTestWalletThroughUi(page);
+  });
+
+  test("renders the send form with mocked balance available", async ({ page }) => {
+    await navigateToSendForm(page);
+    // The form pulls balance via fetchStxBalance which is mocked.
+    await expect(page.locator('[data-roi="send-form"]')).toContainText(
+      MOCKED_BALANCE_DISPLAY,
+      { timeout: 10_000 },
+    );
+  });
+
+  test("flags an invalid recipient address", async ({ page }) => {
+    await navigateToSendForm(page);
+    await fillSendForm(page, { recipient: "not-an-address", amount: "1" });
+
+    await expect(
+      page.locator('[data-roi="send-error-recipient"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-roi="send-error-recipient"]'),
+    ).toContainText(/invalid|address/i);
+  });
+
+  test("flags insufficient funds when amount exceeds balance", async ({ page }) => {
+    await navigateToSendForm(page);
+    // Mocked balance is 1000 STX. Send well past it.
+    await fillSendForm(page, { recipient: VALID_RECIPIENT, amount: "999999" });
+
+    await expect(page.locator('[data-roi="send-error-amount"]')).toBeVisible();
+  });
+
+  test("walks form → confirm-tx summary → PIN prompt", async ({ page }) => {
+    await navigateToSendForm(page);
+    await fillSendForm(page, { recipient: VALID_RECIPIENT, amount: "1" });
+
+    await page.getByRole("button", { name: /Continue/ }).click();
+
+    await expect(page).toHaveURL(/#\/confirm-tx/, { timeout: 10_000 });
+    await expect(page.locator('[data-roi="confirm-view-root"]')).toBeVisible();
+    await expect(page.locator('[data-roi="confirm-summary"]')).toBeVisible();
+    await expect(page.locator('[data-roi="confirm-to-row"]')).toContainText(
+      /ST1PQHQ/,
+    );
+
+    await page.getByRole("button", { name: /Confirm & Send/ }).click();
+
+    await expect(page).toHaveURL(/#\/send/, { timeout: 10_000 });
+    await expect(page.locator('[data-roi="send-confirm-pin"]')).toBeVisible();
+    await expect(page.locator('[data-roi="send-confirm-amount"]')).toContainText(
+      "STX",
+    );
+  });
+
+  test("submits the transaction and lands on tx-result with the mocked txid", async ({ page }) => {
+    await navigateToSendForm(page);
+    await fillSendForm(page, { recipient: VALID_RECIPIENT, amount: "1" });
+
+    await page.getByRole("button", { name: /Continue/ }).click();
+    await expect(page.locator('[data-roi="confirm-view-root"]')).toBeVisible();
+    await page.getByRole("button", { name: /Confirm & Send/ }).click();
+
+    await expect(page.locator('[data-roi="send-confirm-pin"]')).toBeVisible();
+    await enterPin(page, TEST_PIN);
+
+    await expect(page).toHaveURL(/#\/tx-result/, { timeout: 15_000 });
+    await expect(page.locator('[data-roi="tx-result-screen"]')).toBeVisible();
+    await expect(page.locator('[data-roi="tx-result-summary"]')).toBeVisible();
+    // The mocked txid is the lowercase 64-char hex string.
+    await expect(page.locator('[data-roi="tx-result-txid"]')).toContainText(
+      MOCKED_TXID.slice(0, 8),
+    );
+  });
+});

--- a/denvault-extension/e2e/wallet-flows.spec.ts
+++ b/denvault-extension/e2e/wallet-flows.spec.ts
@@ -1,6 +1,16 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { deriveStxAddress } from "../src/utils/accounts/derive";
-import { TEST_MNEMONIC, TEST_PIN } from "./fixtures/mock-wallet";
+import { gotoFresh } from "./helpers/storage";
+import {
+  TEST_MNEMONIC,
+  TEST_PIN,
+  completePinSetup,
+  enterPin,
+  fillVerifyWords,
+  importTestWalletThroughUi,
+  revealAndReadMnemonic,
+  submitWrongPinThreeTimes,
+} from "./helpers/wallet-setup";
 
 /**
  * Interactive E2E for wallet creation, import, and unlock flows (issue #10).
@@ -12,118 +22,6 @@ import { TEST_MNEMONIC, TEST_PIN } from "./fixtures/mock-wallet";
  */
 
 const DEFAULT_NETWORK = "devnet" as const;
-
-async function clearStorage(page: Page) {
-  await page.evaluate(async () => {
-    localStorage.clear();
-    type ChromeLike = { storage?: { local?: { clear?: () => Promise<void> } } };
-    const maybeChrome = (globalThis as unknown as { chrome?: ChromeLike }).chrome;
-    if (maybeChrome?.storage?.local?.clear) {
-      try {
-        await maybeChrome.storage.local.clear();
-      } catch {
-        // localStorage fallback is sufficient for the dev server.
-      }
-    }
-  });
-}
-
-async function gotoFresh(page: Page) {
-  await page.goto("/");
-  await clearStorage(page);
-  await page.reload();
-  await page.waitForLoadState("networkidle");
-}
-
-async function revealAndReadMnemonic(page: Page): Promise<string[]> {
-  const reveal = page.locator('[data-roi="reveal-btn"]');
-  await reveal.waitFor({ state: "visible" });
-  await reveal.click();
-  const grid = page.locator('[data-roi="mnemonic-grid"]');
-  await expect(grid).not.toHaveClass(/mnemonic-grid--hidden/);
-  const wordTexts = await grid.locator(".word-text").allInnerTexts();
-  return wordTexts.map((w) => w.trim()).filter((w) => w.length > 0);
-}
-
-async function extractVerifyOrdinals(page: Page): Promise<[number, number]> {
-  const subtitle = await page.locator('[data-roi="verify-subtitle"]').innerText();
-  const matches = [...subtitle.matchAll(/(\d+)(st|nd|rd|th)/gi)];
-  if (matches.length < 2) {
-    throw new Error(`Expected 2 ordinals in verify subtitle, got: "${subtitle}"`);
-  }
-  return [
-    parseInt(matches[0][1], 10) - 1,
-    parseInt(matches[1][1], 10) - 1,
-  ];
-}
-
-async function fillVerifyWords(page: Page, mnemonicWords: string[]) {
-  const [i1, i2] = await extractVerifyOrdinals(page);
-
-  const w1 = page.locator('[data-roi="verify-word-1-input"]');
-  await w1.click();
-  await w1.fill("");
-  await page.keyboard.type(mnemonicWords[i1], { delay: 10 });
-
-  const w2 = page.locator('[data-roi="verify-word-2-input"]');
-  await w2.click();
-  await w2.fill("");
-  await page.keyboard.type(mnemonicWords[i2], { delay: 10 });
-}
-
-async function enterPin(page: Page, pin: string) {
-  const container = page.locator('[data-roi="pin-input"]').first();
-  await container.waitFor({ state: "visible" });
-  await container.focus();
-  for (const digit of pin) {
-    await page.keyboard.press(digit);
-  }
-}
-
-async function completePinSetup(page: Page, pin: string) {
-  await enterPin(page, pin);
-  await expect(page.locator('[data-roi="pin-input"]')).toBeVisible();
-  await enterPin(page, pin);
-}
-
-async function submitWrongPinThreeTimes(page: Page) {
-  const wrongPin = "000000";
-  const errorSlot = page.locator('[data-roi="pin-error-slot"]');
-
-  // Attempts 1 and 2: expect "Wrong PIN. N attempts remaining."
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    await enterPin(page, wrongPin);
-    await expect(errorSlot).toContainText(/Wrong PIN/i, { timeout: 5_000 });
-    // Wait for the PIN dots to clear before the next attempt.
-    await expect(page.locator('[data-roi="pin-dots-rail"] .pin-dot--filled')).toHaveCount(0);
-  }
-
-  // Attempt 3: error transitions to terminal lockout copy.
-  await enterPin(page, wrongPin);
-}
-
-async function importTestWalletThroughUi(page: Page) {
-  await page.locator('[data-roi="start-secondary-cta"]').click();
-  await expect(page.locator('[data-roi="import-recovery-screen"]')).toBeVisible();
-
-  const textarea = page.locator('[data-roi="import-mnemonic-input"] textarea').first();
-  await textarea.click();
-  await textarea.fill(TEST_MNEMONIC);
-
-  await expect(page.locator('[data-roi="import-cta-primary"]')).toBeEnabled();
-  await page.locator('[data-roi="import-cta-primary"]').click();
-
-  await expect(page.locator('[data-roi="mnemonic-step"]')).toBeVisible();
-  const words = await revealAndReadMnemonic(page);
-
-  await page.locator('[data-roi="cta-primary"]').click();
-  await expect(page.locator('[data-roi="verify-phrase-step"]')).toBeVisible();
-  await fillVerifyWords(page, words);
-  await page.locator('[data-roi="verify-cta-primary"]').click();
-
-  await completePinSetup(page, TEST_PIN);
-  await expect(page).toHaveURL(/#\/user/, { timeout: 10_000 });
-}
 
 test.describe.serial("DenVault wallet flows (issue #10)", () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary

PR A of two for issue #11. Adds interactive E2E coverage for the Send STX flow and extracts shared helpers from `wallet-flows.spec.ts` so future specs (including PR B for dApp RPC) reuse the same primitives.

Covered scenarios in `send-flow.spec.ts`:
- form renders with the mocked balance
- invalid recipient surfaces `send-error-recipient`
- amount above balance surfaces `send-error-amount`
- happy path through `confirm-tx` summary to the PIN prompt
- full submit lands on `tx-result` with the mocked txid

## Network isolation

`helpers/network-mocks.ts` intercepts every Stacks endpoint that the send pipeline can touch:

- `**/extended/v1/address/*/balances`
- `**/v2/accounts/*`
- `**/v2/fees/transaction`
- `**/v2/transactions` (broadcast — never hits real infra)
- `**/extended/v1/tx/*`

A `blockUnmockedStacksHosts` guard is also exported so future specs can fail loudly if a new endpoint slips through.

## Helpers

- `helpers/storage.ts` — `clearStorage`, `gotoFresh`
- `helpers/wallet-setup.ts` — PIN entry, mnemonic reveal/read, verify ordinal parsing, `importTestWalletThroughUi`
- `helpers/network-mocks.ts` — `mockStacksNetwork`, `blockUnmockedStacksHosts`

`wallet-flows.spec.ts` was updated to import from the helpers (no behavior change). One small robustness fix: press `Escape` after typing each verify word so the typeahead dropdown does not intercept the next click in parallel runs.

## Tests

- `pnpm type-check` ✅
- `pnpm exec playwright test e2e/wallet-flows.spec.ts e2e/send-flow.spec.ts --project=chromium` ✅ 10/10 passed (~42s)

The 17 preexisting failures in unrelated specs (density, entry-flow-guards, tx-flow-guards, v55-primitives) are not affected by this PR — verified the touched specs all pass.

## Scope

- ❌ Not in this PR: `e2e/dapp-rpc.spec.ts` (PR B).
- 🔍 Discovery confirmed `window.bitcoin` is injected via `import "./bitcoinjs-lib.js"` in `index.html:38`, so `getAddresses` (with P2TR derivation) will work in the dev server during PR B.

## Files changed

- `denvault-extension/e2e/helpers/storage.ts` (new)
- `denvault-extension/e2e/helpers/wallet-setup.ts` (new)
- `denvault-extension/e2e/helpers/network-mocks.ts` (new)
- `denvault-extension/e2e/send-flow.spec.ts` (new)
- `denvault-extension/e2e/wallet-flows.spec.ts` (refactor to use helpers)

Refs #11