### PR TITLE
docs(branding): migrate URLs from wolfcito to akawolfcito

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ surface: public-wallet
 status: public
 owner: Wolfcito
 pm: pnpm
-repo: https://github.com/wolfcito/stack-sats
-url: https://github.com/wolfcito/stack-sats
+repo: https://github.com/akawolfcito/stack-sats
+url: https://github.com/akawolfcito/stack-sats
 scripts: [dev, build, test, lint]
 -->
 
@@ -164,8 +164,8 @@ The included `counter.clar` contract is for testing:
 
 ## Links
 
-- [Privacy Policy](https://wolfcito.github.io/stack-sats/privacy.html)
-- [Support](https://wolfcito.github.io/stack-sats/support.html)
+- [Privacy Policy](https://akawolfcito.github.io/stack-sats/privacy.html)
+- [Support](https://akawolfcito.github.io/stack-sats/support.html)
 - [Hiro Documentation](https://docs.hiro.so)
 
 ## License

--- a/denvault-extension/PRIVACY.md
+++ b/denvault-extension/PRIVACY.md
@@ -4,7 +4,7 @@ Effective date: 2025-01-04
 
 DenVault is a DenLabs project.
 
-> **Official Policy URL:** https://wolfcito.github.io/stack-sats/privacy.html
+> **Official Policy URL:** https://akawolfcito.github.io/stack-sats/privacy.html
 
 ## Contact
 

--- a/denvault-extension/docs/PRIVACY_POLICY.md
+++ b/denvault-extension/docs/PRIVACY_POLICY.md
@@ -1,9 +1,9 @@
 # Privacy Policy
 
 **DenVault - Stacks Wallet Browser Extension**
-**Last Updated:** January 2025
+**Last Updated:** May 2026
 
-> **Public URL:** https://wolfcito.github.io/stack-sats/privacy.html
+> **Public URL:** https://akawolfcito.github.io/stack-sats/privacy.html
 
 ## Overview
 
@@ -82,13 +82,13 @@ This permanently removes all stored data from your browser.
 ## Open Source
 
 This extension is open source. You can review the code at:
-https://github.com/wolfcito/stack-sats
+https://github.com/akawolfcito/stack-sats
 
 ## Contact
 
 For privacy concerns or questions:
 - Email: wolfcito.learn+privacy@gmail.com
-- Support: https://wolfcito.github.io/stack-sats/support.html
+- Support: https://akawolfcito.github.io/stack-sats/support.html
 
 ## Changes to This Policy
 

--- a/denvault-extension/docs/RELEASE.md
+++ b/denvault-extension/docs/RELEASE.md
@@ -77,9 +77,9 @@ cd den-vault && pnpm build && cd dist && zip -r ../denvault-v1.1.0.zip . -x "*.D
 
 After deployment, verify these URLs work:
 
-- **Homepage:** `https://wolfcito.github.io/stack-sats/`
-- **Privacy Policy:** `https://wolfcito.github.io/stack-sats/privacy.html`
-- **Support:** `https://wolfcito.github.io/stack-sats/support.html`
+- **Homepage:** `https://akawolfcito.github.io/stack-sats/`
+- **Privacy Policy:** `https://akawolfcito.github.io/stack-sats/privacy.html`
+- **Support:** `https://akawolfcito.github.io/stack-sats/support.html`
 
 ---
 
@@ -127,7 +127,7 @@ SUPPORTED METHODS (WBIP/SIP-030):
 • stx_callContract - Call smart contracts
 
 Built with Vue 3, TypeScript, and official Stacks.js libraries.
-Source code: https://github.com/wolfcito/stack-sats
+Source code: https://github.com/akawolfcito/stack-sats
 ```
 
 ### Privacy Tab
@@ -169,7 +169,7 @@ dApp connectivity is handled via content scripts (not host permissions), which i
 
 **Remote Code:** No
 
-**Privacy Policy URL:** `https://wolfcito.github.io/stack-sats/privacy.html`
+**Privacy Policy URL:** `https://akawolfcito.github.io/stack-sats/privacy.html`
 
 ---
 

--- a/denvault-extension/docs/SECURITY.md
+++ b/denvault-extension/docs/SECURITY.md
@@ -3,7 +3,7 @@
 **Stacks Wallet Browser Extension**
 **Version:** 1.0.0
 
-> **Homepage URL:** https://wolfcito.github.io/stack-sats/
+> **Homepage URL:** https://akawolfcito.github.io/stack-sats/
 
 ## Security Model
 

--- a/denvault-extension/docs/SUPPORT.md
+++ b/denvault-extension/docs/SUPPORT.md
@@ -2,7 +2,7 @@
 
 **Stacks Wallet Browser Extension**
 
-> **Public URL:** https://wolfcito.github.io/stack-sats/support.html
+> **Public URL:** https://akawolfcito.github.io/stack-sats/support.html
 
 ## Getting Help
 
@@ -15,7 +15,7 @@
 ### Issue Tracker
 
 Report bugs and request features:
-https://github.com/wolfcito/stack-sats/issues
+https://github.com/akawolfcito/stack-sats/issues
 
 ### Community
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,7 +138,7 @@
     </header>
 
     <p style="text-align:center; color:var(--text-muted); max-width:560px; margin:0 auto 30px; font-size:0.95rem;">
-      Open-source and built with production-grade security. Independent project by DenLabs. Review the <a href="https://github.com/wolfcito/stack-sats" style="color:var(--primary); text-decoration:none;">source code</a> before storing significant funds.
+      Open-source and built with production-grade security. Independent project by DenLabs. Review the <a href="https://github.com/akawolfcito/stack-sats" style="color:var(--primary); text-decoration:none;">source code</a> before storing significant funds.
     </p>
 
     <div class="security-badges">
@@ -177,11 +177,11 @@
     </div>
 
     <div class="cta">
-      <a href="https://github.com/wolfcito/stack-sats" class="btn">View on GitHub</a>
+      <a href="https://github.com/akawolfcito/stack-sats" class="btn">View on GitHub</a>
       <div class="links">
         <a href="privacy.html">Privacy Policy</a>
         <a href="support.html">Support</a>
-        <a href="https://github.com/wolfcito/stack-sats" target="_blank">GitHub</a>
+        <a href="https://github.com/akawolfcito/stack-sats" target="_blank">GitHub</a>
       </div>
     </div>
 
@@ -192,7 +192,7 @@
         <a href="support.html">Support</a>
       </p>
       <p style="margin-top: 10px;">
-        DenVault is a <a href="https://github.com/wolfcito" target="_blank">DenLabs</a> project.
+        DenVault is a <a href="https://github.com/akawolfcito" target="_blank">DenLabs</a> project.
       </p>
     </footer>
   </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -121,7 +121,7 @@
     </nav>
 
     <h1>Privacy Policy</h1>
-    <p class="updated">Last Updated: January 2026</p>
+    <p class="updated">Last Updated: May 2026</p>
 
     <!-- LIMITED USE DISCLOSURE - Required by Chrome Web Store -->
     <div class="limited-use">
@@ -299,7 +299,7 @@
     <h2>Open Source</h2>
     <p>
       This extension is open source. You can review the code at:<br>
-      <a href="https://github.com/wolfcito/stack-sats" target="_blank">GitHub Repository</a>
+      <a href="https://github.com/akawolfcito/stack-sats" target="_blank">GitHub Repository</a>
     </p>
 
     <h2>Contact</h2>
@@ -318,7 +318,7 @@
       <p>
         <a href="index.html">Home</a> |
         <a href="support.html">Support</a> |
-        <a href="https://github.com/wolfcito/stack-sats" target="_blank">GitHub</a>
+        <a href="https://github.com/akawolfcito/stack-sats" target="_blank">GitHub</a>
       </p>
     </footer>
   </div>

--- a/docs/support.html
+++ b/docs/support.html
@@ -188,7 +188,7 @@
       <h3>Need More Help?</h3>
       <p>
         <strong>GitHub Issues:</strong><br>
-        <a href="https://github.com/wolfcito/stack-sats/issues" target="_blank">Report a bug or request a feature</a>
+        <a href="https://github.com/akawolfcito/stack-sats/issues" target="_blank">Report a bug or request a feature</a>
       </p>
       <p style="margin-top: 15px;">
         <strong>Email:</strong><br>
@@ -204,7 +204,7 @@
       <p>
         <a href="index.html">Home</a> |
         <a href="privacy.html">Privacy Policy</a> |
-        <a href="https://github.com/wolfcito/stack-sats" target="_blank">GitHub</a>
+        <a href="https://github.com/akawolfcito/stack-sats" target="_blank">GitHub</a>
       </p>
     </footer>
   </div>


### PR DESCRIPTION
## Summary

Updates every privacy / support / release / security / homepage doc to point at the live GitHub Pages host (`akawolfcito.github.io/stack-sats/`) and the canonical repo (`github.com/akawolfcito/stack-sats`). Both URLs return HTTP 200 today; the legacy `wolfcito.github.io/stack-sats/` URLs returned 404, which would block the Chrome Web Store review.

The on-disk repo name stays `stack-sats` per the user's call. Only URL host references change.

## Changes

Tracked files updated (9):

- `README.md` — workspace README links
- `denvault-extension/PRIVACY.md`
- `denvault-extension/docs/PRIVACY_POLICY.md` (also bumped `Last Updated` to May 2026)
- `denvault-extension/docs/RELEASE.md` — CWS submission text
- `denvault-extension/docs/SECURITY.md`
- `denvault-extension/docs/SUPPORT.md`
- `docs/index.html` — GitHub Pages homepage
- `docs/privacy.html` — GitHub Pages privacy page (also bumped `Last Updated`)
- `docs/support.html` — GitHub Pages support page

`NOTES_TO_REVIEWER.md` is untracked (gitignored) and was skipped intentionally.

## Verification

```bash
# Live URLs (verified before opening this PR)
curl -sI https://akawolfcito.github.io/stack-sats/privacy.html | head -3
curl -sI https://akawolfcito.github.io/stack-sats/support.html | head -3
curl -sI https://akawolfcito.github.io/stack-sats/         | head -3
# All three return HTTP/2 200.
```

## Out of scope

- ZIP rebuild and GitHub Pages refresh after merge (PR 3).
- Repo rename to `denvault` (deferred per user call).
- Functional code changes.

Refs #3