### PR TITLE
fix(pre-cws): P0 hardening for the Chrome Web Store resubmit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ docs/agent-loop.md
 
 # CWS build artifacts
 *.zip
+denvault-v*/
 
 # Playwright test snapshots (generated locally)
 den-vault/e2e/*-snapshots/

--- a/denvault-extension/docs/handoff/pre-cws-e2e-review-plan.md
+++ b/denvault-extension/docs/handoff/pre-cws-e2e-review-plan.md
@@ -1,0 +1,317 @@
+# Pre-CWS E2E Review Plan — DenVault v1.1.0
+
+**Date:** 2026-05-09 (revisado security-first)
+**Goal:** Validar flujos E2E contra estándares existentes del ecosistema Stacks (no creamos normas) y confirmar que nuestra propuesta **security-first con UX que no fricciona** se sostiene antes de subir al Chrome Web Store.
+
+## Filosofía de la revisión
+
+1. **Adoptar, no inventar.** Cumplimos contra:
+   - `@stacks/connect v8` (request/response shape)
+   - WBIP (Wallet Best Practices)
+   - SIP-030 (wallet integration)
+   - SIP-018 (structured data signing)
+   - JSON-RPC 2.0 envelope
+   - BIP-39 (mnemonic 12/24)
+   - Manifest V3 + CSP estricto
+
+2. **Security-first, UX-driven.** Orden de prioridad innegociable:
+   - **Seguridad** > **claridad** > **velocidad** > **estética**.
+   - Si una mejora de UX reduce visibilidad de un riesgo (origen, post-conditions, fees, network mismatch), **se rechaza**.
+   - Ganamos contra Leather/Xverse haciendo que **lo seguro sea también lo más fácil** (no escondiendo seguridad detrás de "advanced").
+
+### ¿Qué es un "UX delta"?
+
+Un **UX delta** es la diferencia medible (en clicks, segundos, decisiones, o claridad de información) entre el flujo en DenVault vs el mismo flujo en Leather o Xverse para un usuario nuevo.
+
+Tipos de delta:
+- **Delta de fricción**: clicks/segundos hasta completar tarea (menos = mejor).
+- **Delta de claridad**: información de seguridad visible sin abrir submenús (más = mejor).
+- **Delta de error**: cuántos pasos toma recuperarse de un error (menos = mejor).
+- **Delta de confianza**: cuántas veces el usuario tiene que adivinar qué pasa (menos = mejor).
+
+**Ejemplo concreto** (T2.2 conectar a dApp):
+- Leather: dApp → click connect → popup → click "Approve" → click "OK" = **3 clicks, no muestra origen verificado, no muestra qué método se va a llamar después**
+- DenVault objetivo: dApp → click connect → popup muestra **origen + favicon + lista de métodos que pedirá** → click "Connect" = **1 click, muestra todo lo que importa para decidir**
+
+El delta no es "menos clicks" — es "menos clicks **y** más información de seguridad".
+
+---
+
+## Estado actual (cubierto)
+
+| Área | Spec | Cobertura |
+|---|---|---|
+| Confirmation UI | `confirmation.approval.e2e.spec.ts` | ✅ |
+| getAddresses + signMessage + transferStx (legacy popup) | `dapp-rpc.spec.ts` | ✅ |
+| Send STX flow | `send-flow.spec.ts`, `tx-flow-guards.spec.ts` | ✅ |
+| Wallet creation/import/unlock | `wallet-flows.spec.ts`, `entry-flow-guards.spec.ts` | ✅ |
+| Home dashboard contract | `home.dashboard.e2e.spec.ts` | ✅ |
+| Density / responsive | `density.spec.ts` | ✅ |
+| Visual regression (golden) | `golden-*.spec.ts` | ✅ |
+| DenSignal emit hooks | `denlabs-integration.spec.ts` | ✅ |
+| ROI primitives | `v55-primitives.spec.ts` | ✅ |
+
+---
+
+## Gaps a cubrir antes del CWS submit
+
+### Tier 0 — SEGURIDAD CRÍTICA (promovido por security-first)
+
+> Antes era Tier 4 "compliance"; con security-first sube a Tier 0 porque es el **diferenciador**.
+
+| # | Check | Cómo se prueba |
+|---|---|---|
+| T0.1 | No `eval` / `Function` / `importScripts` en bundle final | `grep -rE "eval\(\|new Function\|importScripts" dist/` → cero hits |
+| T0.2 | No logs con mnemonic / PIN / private key / seed | Auditar todas las invocaciones de `console.*` y `secureLog` en bundle minificado |
+| T0.3 | CSP estricto (sin `unsafe-eval`; solo `wasm-unsafe-eval`) | Leer `manifest.json` dentro del ZIP, comparar con baseline |
+| T0.4 | Auto-lock dispara a 5 min de inactividad | E2E vitest con fake timer + verificar que mnemonic se borra de memoria |
+| T0.5 | Brute-force lockout escalonado (30s→2m→10m→1h) tras N intentos fallidos | E2E que falla PIN N veces y verifica countdown UI + bloqueo persistente cross-reload |
+| T0.6 | Origen de la dApp **siempre visible** en Confirmation (no truncado, con tooltip si es largo) | E2E con origen largo + visual regression |
+| T0.7 | Network mismatch warning: si dApp pide mainnet pero wallet está en testnet, banner rojo bloqueante | E2E |
+| T0.8 | Post-conditions de `stx_callContract` se renderizan legibles (no JSON crudo) | E2E con post-condition real de ALEX |
+| T0.9 | Storage no se desborda con 5+ wallets, 20+ tokens, 100+ tx history | E2E con seed grande + medir bytes |
+| T0.10 | Side-channel: el popup no expone mnemonic vía `chrome.storage` accesible por content scripts | Auditoría manual + test que content script intenta leer y falla |
+
+### Tier 1 — COMPATIBILIDAD ESTÁNDAR (bloqueador funcional)
+
+| # | Flow | Estándar | Por qué bloquea |
+|---|---|---|---|
+| T1.1 | `stx_signStructuredData` E2E con payload SIP-018 real | SIP-018 | Implementado, sin E2E. Si rompe, DEX/governance no funcionan |
+| T1.2 | `stx_callContract` con post-conditions (ver también T0.8) | WBIP / SIP-005 | Crítico DeFi |
+| T1.3 | `stx_deployContract` confirm + broadcast | SIP-030 | Devs lo prueban primero |
+| T1.4 | Queue mode (no solo legacy popup) full content-script flow | WBIP | `dapp-rpc.spec.ts` solo cubre legacy popup |
+| T1.5 | Carga unpacked en Chrome estable + Brave + Edge (smoke manual) | Manifest V3 | 5 min cada uno |
+| T1.6 | Cambio de network mid-session refleja en getAddresses + Confirmation | SIP-030 | Falta E2E de cambio caliente |
+
+### Tier 2 — UX DELTAS (security-aware)
+
+> Reformulado: ya no buscamos "menos clicks por menos clicks". Buscamos **delta de claridad de seguridad** sin agregar fricción.
+
+| # | Flow | Delta esperado vs Leather/Xverse | Métrica |
+|---|---|---|---|
+| T2.1 | Onboarding (instalar → crear → backup phrase → PIN → home) | DenVault muestra **fortaleza del PIN visualmente** y **forzar verificación de phrase** sin sentir tutorial pesado | Tiempo + comprensión |
+| T2.2 | Conectar a dApp 1ª vez (consent screen) | Mostrar **origen + favicon + métodos que la dApp pedirá** (no solo "do you allow?") en 1 pantalla | # clicks + info visible |
+| T2.3 | Recovery tras 3 PIN fallidos (issue #18) | **Countdown visible** + opción "import phrase to reset" sin perder UX | Sin reload manual |
+| T2.4 | Account switcher (3+ cuentas) | Cambio < 1s **y** cada cuenta muestra address truncada + checksum visible | Latencia + claridad |
+| T2.5 | Send STX: campo Memo, fee dinámica, network chip | Memo opcional con hint de "visible público en chain"; fee siempre visible antes de confirm | UX text + visibilidad |
+| T2.6 | Error de red en transferStx | Toast con retry **explica si la TX se broadcasted o no** (no ambigüedad) | Mensaje exacto |
+| T2.7 | Receive: copy address con QR | Feedback < 200ms **y** address completa visible (no truncada al copy) | Time-to-feedback |
+| T2.8 | Side panel mode | Persiste sin re-unlock al cambiar de tab; lock manual con 1 click visible | Persistencia + lock |
+
+### Tier 3 — COMPATIBILIDAD CON dApps REALES (smoke manual)
+
+**Setup común:**
+- Cargar DenVault como `unpacked` desde `dist/`
+- Importar la **canonical test phrase** documentada en `internal-docs/test-phrase-v1.1.0.md` (ver sección "Canonical Test Phrase" más abajo). Esta phrase tiene **0 fondos en mainnet** (verificado) y **STX testnet vía faucet**.
+- Network chip → Testnet por defecto. Para T3.2/T3.3/T3.4/T3.5/T3.7 conectamos a mainnet **en modo preview** (NUNCA firmar TX), seguros porque la address mainnet derivada tiene balance 0.
+- DevTools abierto en Network + Console todo el tiempo
+- Documentar: ✅ pass / ⚠️ warn / ❌ fail con screenshot + nota
+
+**Criterio global de éxito:** 8/8 conectan sin errores de consola, address correcta, y `connect.stacks.com` ejecuta los 5 métodos RPC sin romper.
+
+#### T3.1 — Hiro Explorer (`explorer.hiro.so`)
+**Tipo:** infra / read-only
+**Pasos:**
+1. Abrir explorer.hiro.so
+2. Click "Connect Wallet" (esquina sup. derecha)
+3. Verificar que el popup de DenVault muestra origen `explorer.hiro.so` con favicon
+4. Approve → verificar que el explorer muestra la address STX testnet de DenVault
+5. Click "Disconnect" en explorer → verificar que DenVault no muestra sesión activa
+**Pass criteria:** address coincide, origen visible, disconnect limpio.
+
+#### T3.2 — ALEX (`app.alexlab.co`)
+**Tipo:** DEX (mainnet, **no firmamos TX**)
+**Pasos:**
+1. Abrir app.alexlab.co (mainnet)
+2. Connect wallet → DenVault popup
+3. Approve → ALEX debe mostrar address mainnet
+4. Abrir un swap STX → aBTC, ingresar 0.001 STX, hacer **preview** (NO firmar)
+5. Cuando ALEX dispare `stx_callContract`, verificar en DenVault Confirmation:
+   - Función contrato visible: `swap-helper`
+   - **Post-conditions** legibles (no JSON crudo)
+   - Fee dinámica visible
+6. **Cancelar** (no firmar)
+**Pass criteria:** post-conditions render legible, no error de consola, cancelar no rompe la sesión.
+
+#### T3.3 — Arkadiko (`arkadiko.finance`)
+**Tipo:** DeFi vaults
+**Pasos:**
+1. Abrir arkadiko.finance
+2. Connect → Approve en DenVault
+3. Verificar dashboard muestra address + balance USDA/STX
+4. Abrir un vault existente (read-only) — si hay vaults dummy en testnet, mejor
+5. Click "Create vault" → llenar datos → cuando dispare `stx_callContract`, verificar en DenVault:
+   - Múltiples post-conditions (STX out, USDA in)
+   - Origen + función contrato visibles
+6. **Cancelar**
+**Pass criteria:** multi-step contract call preview legible.
+
+#### T3.4 — Bitflow (`app.bitflow.finance`)
+**Tipo:** DEX / aggregator
+**Pasos:**
+1. Abrir app.bitflow.finance
+2. Connect wallet
+3. Verificar lista de pools carga sin error
+4. Seleccionar pool STX/aeUSDC, ingresar amount
+5. Disparar swap → verificar en DenVault Confirmation:
+   - Función + contrato + post-conditions
+6. **Cancelar**
+**Pass criteria:** aggregator routing visible en Confirmation, no rompe con swaps multi-hop.
+
+#### T3.5 — Velar (`app.velar.com`)
+**Tipo:** DEX / perps
+**Pasos:**
+1. Abrir app.velar.com
+2. Connect wallet
+3. Abrir swap STX/USDh
+4. Disparar swap → en DenVault verificar:
+   - Provider list (Velar muestra varios providers para connect)
+   - DenVault aparece como opción
+   - Confirmation muestra contrato + post-conditions
+5. **Cancelar**
+**Pass criteria:** DenVault aparece en provider list de @stacks/connect, no es rechazado.
+
+#### T3.6 — Lockstacks (`lockstacks.com`)
+**Tipo:** Stacking / PoX
+**Pasos:**
+1. Abrir lockstacks.com
+2. Connect wallet
+3. Ver opciones de Stack/Delegate
+4. Seleccionar "Stack independently" → llenar amount
+5. Disparar `stx_callContract` (al `pox-4` contract) → verificar en DenVault:
+   - Contrato `SP000000...pox-4` visible
+   - Función `stack-stx` visible
+   - Post-conditions de lock STX legibles
+   - Cycles count visible si la dApp lo manda en function args
+6. **Cancelar**
+**Pass criteria:** PoX contract calls (alta sensibilidad de seguridad) muestran toda la info crítica.
+
+#### T3.7 — Gamma (`gamma.io`)
+**Tipo:** NFT marketplace (SIP-009)
+**Pasos:**
+1. Abrir gamma.io
+2. Connect wallet
+3. Ver perfil + cualquier NFT testnet asociado
+4. Si hay opción de "list NFT" o "make offer" en testnet, disparar la firma:
+   - Puede ser `stx_signStructuredData` (SIP-018) para offers off-chain
+   - O `stx_callContract` para list on-chain
+5. Verificar en DenVault Confirmation que el structured data es **legible** (no hex crudo)
+6. **Cancelar**
+**Pass criteria:** SIP-018 structured data se renderiza human-readable.
+
+#### T3.8 — Stacks Connect Demo (`connect.stacks.com`) ⭐ BENCHMARK
+**Tipo:** Reference dApp oficial
+**Pasos (los 5 métodos):**
+1. Abrir connect.stacks.com
+2. Connect → DenVault popup → approve
+3. **Método 1 — getAddresses:** verificar que la demo muestra BTC + STX addresses correctas
+4. **Método 2 — stx_signMessage:** ingresar mensaje "hello denvault" → sign → DenVault muestra el mensaje literal en Confirmation → approve → demo verifica firma
+5. **Método 3 — stx_signStructuredData (SIP-018):** ingresar payload estructurado → sign → DenVault renderiza campos legibles → approve → demo verifica
+6. **Método 4 — stx_transferStx:** ingresar 0.0001 STX hacia la misma address (testnet) → DenVault muestra fee + post-conditions → approve → broadcast → verificar txid en Hiro Explorer testnet
+7. **Método 5 — stx_callContract:** llamar a un contrato testnet de prueba → DenVault muestra función + args + post-conditions → approve → broadcast
+**Pass criteria:** los 5 ejecutan sin error, las firmas verifican, los txids existen en explorer testnet.
+
+> **Esta es la prueba más importante.** Si los 5 pasan en `connect.stacks.com`, las otras 7 dApps probablemente funcionarán por inercia.
+
+---
+
+## Recomendación de ejecución (revisada con security-first)
+
+**Fase A — Imprescindible antes de subir** (~3-4 días):
+- **T0.1 — T0.7** (todo Tier 0 excepto T0.9 y T0.10 que son hardening)
+- **T1.1, T1.4, T1.5** (compatibilidad estándar)
+- **T2.2, T2.3** promovidos a Fase A (consent screen + lockout recovery son **seguridad visible**)
+- **T3.1, T3.2, T3.6, T3.8** (Hiro Explorer + ALEX + Lockstacks + Stacks Connect Demo — cubren read, swap con post-conditions, PoX y reference)
+
+**Fase B — Nice-to-have, no bloquea CWS** (post-submit, antes de promover):
+- T0.9, T0.10
+- T1.2, T1.3, T1.6
+- T2.1, T2.4–T2.8 (UX deltas restantes)
+- T3.3, T3.4, T3.5, T3.7 (dApps secundarias)
+
+**Fase C — Si sale rejection:** lo que el reviewer pida específicamente.
+
+---
+
+## Decisiones (resueltas 2026-05-09)
+
+1. ✅ **T2.2 + T2.3 promovidos a Fase A** (consent screen claro + lockout recovery son seguridad visible).
+
+2. ✅ **Fase A en Tier 3 = T3.1 + T3.2 + T3.6 + T3.8** (explorer/read, swap con post-conditions, PoX/staking, reference oficial).
+
+3. ✅ **Reformulada — la frontera de seguridad NO es testnet vs mainnet**, es phrase-con-fondos vs phrase-sin-fondos. Una BIP-39 deriva ambas redes desde el mismo seed; el network chip solo cambia a qué chain consultas/transmites. Por lo tanto:
+   - Usamos **una sola canonical test phrase** sin fondos mainnet (verificado en explorer)
+   - Network chip por defecto: testnet
+   - Los smokes mainnet (T3.2/T3.3/T3.4/T3.5/T3.7) son **modo preview** — nunca firmamos. Si por accidente se firmara, no hay nada que perder porque la address mainnet derivada tiene balance 0.
+
+4. ✅ **Issue #18 (lockout recovery) es BLOQUEADOR** — se cierra antes del submit.
+
+5. ✅ **Generamos canonical test phrase**: ver sección "Canonical Test Phrase" más abajo.
+
+---
+
+## Canonical Test Phrase (operativa)
+
+**Qué es:** una BIP-39 phrase de 12 palabras dedicada al testing E2E manual de DenVault. Reutilizable entre sesiones y releases.
+
+**Por qué importa:** con security-first, no queremos depender de phrases ad-hoc generadas en cada smoke (riesgo de filtración accidental, riesgo de mezclar con phrase real). Una phrase canónica documentada en `internal-docs/` (gitignored) elimina ese riesgo.
+
+**Plan de generación (recomendado):**
+
+1. Cargar DenVault como unpacked desde `dist/`
+2. Click **"Create Wallet"** → guardar las 12 palabras
+3. Crear archivo `internal-docs/test-phrase-v1.1.0.md` (ya gitignored) con:
+   ```
+   # Canonical Test Phrase — DenVault v1.1.0
+
+   **Date generated:** YYYY-MM-DD
+   **Source:** DenVault Create Wallet flow
+   **Purpose:** E2E manual smokes, Tier 3 dApps testing
+
+   ## Phrase
+   word1 word2 word3 ... word12
+
+   ## Derived addresses
+   - STX mainnet (account 0): SP...
+   - STX testnet (account 0): ST...
+   - BTC mainnet (account 0): bc1...
+
+   ## Verification (mainnet must be empty)
+   - explorer.hiro.so/address/SP... → 0 TX, 0 STX → ✅ confirmed empty
+   ```
+4. Verificar la address STX mainnet derivada en https://explorer.hiro.so/ → debe mostrar **0 TX, 0 balance**. Si no, regenerar y repetir.
+5. Network chip en DenVault → Testnet
+6. Pedir STX testnet en https://explorer.hiro.so/sandbox/faucet?chain=testnet (envía a la address `ST...`)
+7. Esperar 1-2 bloques, verificar balance > 0 en testnet
+8. Listo — esta phrase queda como referencia oficial para Fase A y siguientes
+
+**Reglas de uso:**
+- ⛔ Nunca enviar fondos reales (mainnet) a esta phrase
+- ⛔ Nunca compartir el archivo `test-phrase-v1.1.0.md` (verificar `git status` no la rastree)
+- ⛔ No reusar entre máquinas físicas — si necesitas testear en otra máquina, regenera otra phrase y documenta `test-phrase-v1.1.0-machine-N.md`
+- ✅ Reusable entre sesiones de Claude Code en la misma máquina
+- ✅ Si se filtra accidentalmente: rotar (generar nueva, actualizar doc), sin pánico — no hay valor en juego
+
+---
+
+## Próximos pasos (post-aprobación)
+
+1. Crear issues GitHub en `wolfcito/stack-sats` para cada item de Fase A
+2. Branch `chore/pre-cws-e2e-hardening`
+3. Implementar tests T1.1, T1.4, T0.4–T0.8 (los que requieren código nuevo)
+4. Cerrar issue #18 (T2.3 / lockout recovery)
+5. Ejecutar Tier 3 manual y documentar resultados aquí mismo (sección "Resultados Tier 3")
+6. Si todo verde: subir al CWS dashboard usando `cws-submission-handoff.md`
+
+## Resultados Tier 3 (a llenar durante ejecución)
+
+| dApp | Fecha | Resultado | Notas | Screenshot |
+|---|---|---|---|---|
+| T3.1 Hiro Explorer | — | ⏳ | — | — |
+| T3.2 ALEX | — | ⏳ | — | — |
+| T3.3 Arkadiko | — | ⏳ | — | — |
+| T3.4 Bitflow | — | ⏳ | — | — |
+| T3.5 Velar | — | ⏳ | — | — |
+| T3.6 Lockstacks | — | ⏳ | — | — |
+| T3.7 Gamma | — | ⏳ | — | — |
+| T3.8 Stacks Connect Demo | — | ⏳ | — | — |

--- a/denvault-extension/docs/reviews/2026-08-10-pre-cws-wip-review.md
+++ b/denvault-extension/docs/reviews/2026-08-10-pre-cws-wip-review.md
@@ -1,0 +1,102 @@
+# Pre-CWS — Revisión del WIP sin commitear
+
+**Fecha:** 2026-08-10
+**Objetivo:** determinar si el trabajo pendiente del 2-may está completo para empaquetar y subir al Chrome Web Store.
+**Base:** `main` @ `472000e` + working tree sin commitear.
+
+---
+
+## 1. Verificación ejecutada (toda verde)
+
+| Check | Comando | Resultado |
+|---|---|---|
+| Tipos | `pnpm type-check` | limpio, sin salida de error |
+| Unit tests | `pnpm test` | **936/936** en 40 archivos |
+| Contratos UI | `pnpm contract:check` | **160/160** |
+| Build | `pnpm build` | ✓ en 5.37s |
+| Hardening build | `pnpm verify:production` | PASS (1 warning, ver §4) |
+
+Nota: la memoria del proyecto registraba 415 tests. El número real hoy es **936** — la suite creció con los PRs #17–#26 de mayo.
+
+Los tests nuevos del WIP corren y pasan:
+- `src/composables/useCanonicalRequest.test.ts` — 8 tests
+- `src/test/background-queue.test.ts` — 9 tests
+
+---
+
+## 2. Qué hace el WIP (P0-3 + P1-4)
+
+**Archivos nuevos**
+- `src/composables/useCanonicalRequest.ts` — `fetchCanonicalRequest(requestId)` pide a background los params canónicos vía `GET_ACTIVE_REQUEST`. Devuelve `null` ante cualquier anomalía (sin id, sin `chrome`, `ok:false`, id que no coincide, canal roto, respuesta vacía). Los 8 tests cubren exactamente esos 8 caminos.
+
+**Archivos modificados**
+- `public/background.js` (+118/-8) — handler `handleGetActiveRequest` (valida que el id coincida con `activeRequest.id`), `notifyPopupResponseError` que emite `DAPP_RESPONSE_ERROR`, y validación de id en `handleDappApprove` / `handleDappReject` que ahora responden con error explícito en vez de un `console.warn` silencioso.
+- `src/components/Confirmation.vue` (+62/-13) — en modo cola, `handleConfirm` busca los params canónicos y **firma contra esos bytes**; si no los consigue, aborta y rechaza en vez de firmar a ciegas. Se suscribe a `DAPP_RESPONSE_ERROR` con limpieza en `onBeforeUnmount`.
+
+**Veredicto:** el WIP es trabajo sólido, coherente y bien testeado para lo que declara. Debe commitearse.
+
+---
+
+## 3. Huecos encontrados
+
+### H1 — Divergencia entre lo que se muestra y lo que se firma (nuevo, no documentado)
+
+La firma pasó a usar `signingPayload` (canónico), pero **toda la capa de display sigue leyendo `props.payload`**:
+
+- `Confirmation.vue:116` — descripción del método
+- `:121-154` — params renderizados (destinatario, monto, contrato)
+- `:172, :196` — lógica de presentación
+- `:535` — panel de payload crudo (`JSON.stringify(props.payload)`)
+
+Bajo la amenaza exacta que este fix ataca (payload del popup mutado entre display y aprobación), el resultado es que **el usuario ve una cosa y firma otra**. Antes ambos venían de la misma fuente mutada; ahora la firma quedó protegida y el display no.
+
+**Cierre propuesto:** traer el canónico en `onMounted` y renderizar desde él, dejando `props.payload` solo como fallback del modo legacy. Es la continuación natural del mismo fix.
+
+### H2 — P0-3 queda parcialmente cerrado (el propio autor lo documentó)
+
+Comentario textual en `background.js`:
+
+> *"the popup still constructs the signed `result` (the mnemonic lives in the popup session)... Future hardening: move signing to the background so `activeRequest.params` becomes the only source of payload bytes."*
+
+La garantía real que aporta el WIP es **anti-replay / anti-stale** (un approve viejo no puede secuestrar otro request), no integridad criptográfica extremo a extremo. El cierre completo es mover la firma al background: cambio arquitectónico, no apto para un sprint de salida.
+
+### H3 — Issue #18 sigue sin arreglar
+
+`src/views/UnlockView.vue:63` continúa mostrando `"Too many attempts. Reset wallet to continue."` y la línea `:124` deshabilita el input de forma terminal (`attemptsRemaining <= 0`). No hay countdown ni reenganche por timer, pese a que `LockoutManager` sí implementa la escalada 30s→2m→10m→1h.
+
+El plan pre-CWS del 9-may lo marca **bloqueador explícito**. Es además el hueco con más probabilidad de que lo toque un reviewer de Google: fallar el PIN tres veces es lo primero que se prueba en una wallet, y hoy el único camino de salida es resetear la wallet.
+
+### H4 — El WIP está sin commitear, sobre `main`, sin rama ni PR
+
+Contradice la regla de trabajar siempre en feature branch. Riesgo real de pérdida: son ~180 líneas de código más dos specs que llevan 3 meses solo en disco.
+
+---
+
+## 4. Menor
+
+`verify:production` reporta **3 `console.log` en `dist/`**, uno de ellos en `dist/background.js`. No filtra material sensible (el logger redacta mnemonic/PIN/privateKey), pero conviene limpiarlo antes de publicar.
+
+---
+
+## 5. Estado del artefacto
+
+`denvault-v1.1.0.zip` en la raíz del repo es del **1-may** y no contiene nada de esto. **Hay que regenerarlo** con `pnpm release:zip` después de aplicar los cambios. No reutilizar ese ZIP.
+
+Sobre P0-2 del audit (API key de Hiro en el bundle): **no aplica**. La key solo se usa en la rama `devnet` (`src/utils/balance/index.ts:22-32`), mainnet y testnet usan endpoints públicos sin credencial, y el ZIP no contiene ninguna ocurrencia de `v1/ext/`. La única mención de `api.platform.hiro.so` en el bundle está dentro del allowlist de hosts. Queda como tarea de proceso: un guard en `verify-production.sh` que falle si algún día se compila con una `.env` que traiga la key.
+
+---
+
+## 6. Camino propuesto al submit
+
+| # | Tarea | Tipo |
+|---|---|---|
+| 1 | Rama `fix/pre-cws-p0-hardening` + commit del WIP tal cual (todo verde) | mecánico |
+| 2 | H1 — renderizar el display desde el canónico | TDD, acotado |
+| 3 | H3 — countdown de lockout y reenganche en `UnlockView` (cierra #18) | TDD, acotado |
+| 4 | H4 menor — limpiar los `console.log` de `dist` + guard de la key en `verify-production.sh` | mecánico |
+| 5 | `pnpm verify:production` + `pnpm release:zip` → ZIP nuevo | verificación |
+| 6 | Subir al dashboard con el mapeo de `docs/handoff/cws-submission-handoff.md` | manual |
+
+**En paralelo desde ya:** registrar la cuenta Google Developer ($5). Es el único paso cuya duración no controlamos y bloquea el punto 6.
+
+**Se difiere con justificación escrita:** P0-1 (mnemonic en `SecureBuffer`) y H2 (firma en background). Ambos son arquitectónicos y van a v1.2.0.

--- a/denvault-extension/docs/reviews/red-team-2026-05-02.md
+++ b/denvault-extension/docs/reviews/red-team-2026-05-02.md
@@ -1,0 +1,191 @@
+# DenVault — Red Team Audit
+
+**Date:** 2026-05-02
+**Scope:** Full extension app (auth, send/confirm, dApp/RPC, wallet mgmt, security primitives, router)
+**Methodology:** Adversarial QA + security review (frontend flows, state machine, crypto, message passing)
+**Reviewers:** 6 parallel sub-audits, synthesized
+
+---
+
+## Executive Summary
+
+| Severity | Count | Category |
+|---|---|---|
+| **P0 — Critical** | 3 | Mnemonic in JS string, API key in bundle, UI payload-tampering |
+| **P1 — High** | 8 | Origin spoofing, address-cache replay, PIN-only entropy, silent approval drop, WASM-CSP, lockout dead end, double-broadcast race, draft singleton cross-context |
+| **P2 — Medium** | 12 | Truncation phishing, rate-limit bypass, page-script CustomEvent forge, weak wipe, etc. |
+| **P3 — Low / Hardening** | 9 | Salt size, PBKDF2 ceiling, clipboard TTL, biometric stub, etc. |
+| **Verified OK** | 30+ | Cryptography core, route guards, anti-double-submit, origin checks |
+
+**Verdict:** Cryptographic core is solid (AES-256-GCM, PBKDF2, unique IV/salt). Production blockers are in **key-material handling**, **dApp boundary trust**, and **mnemonic memory hygiene**. Suitable for testnet today; mainnet release should resolve P0 + top P1 issues first.
+
+---
+
+## P0 — Critical
+
+### P0-1. Mnemonic stored as JavaScript string (memory hygiene)
+**File:** `src/utils/security/session.ts:48`
+**Issue:** `_decryptedMnemonic: string | null` — JS strings are immutable and cannot be wiped. The `SecureBuffer` utility exists but is not used for the mnemonic.
+**Impact:** Cold-boot / forensic memory recovery of the unlocked seed; survives GC indefinitely.
+**Repro:** Unlock wallet → take heap snapshot via DevTools → search for known phrase substring → present.
+**Fix direction:** Migrate to `SecureBuffer` end-to-end; derive private keys from buffer-backed source.
+
+### P0-2. Hiro API key embedded in production bundle
+**File:** `src/lib/balance/index.ts:25-27`
+**Issue:** `VITE_PLATFORM_HIRO_API_KEY` injected via `import.meta.env` ships in `dist/assets/*.js` plaintext and is concatenated into URLs (`/v1/ext/${apiKey}/...`).
+**Impact:** Anyone who downloads the published extension can extract the key → quota abuse, rate-limit exhaustion, traffic correlation.
+**Repro:** `grep -r "PLATFORM_HIRO" dist/` after `pnpm build`.
+**Fix direction:** Backend proxy (Vercel function or similar) for authenticated endpoints; frontend only sees a public, restricted endpoint.
+
+### P0-3. UI payload tampering (no integrity check between background ↔ popup)
+**File:** `src/components/Confirmation.vue:58-80` ↔ `public/background.js:337-372`
+**Issue:** The popup receives `props.payload` and `handleConfirm()` re-sends an approval object to background; background does not verify the popup's payload matches `activeRequest.params`. A compromised popup (XSS via dApp-controlled fields, full-page mode injection) could mutate amount/recipient between display and signing.
+**Impact:** Loss of approval integrity — user approves payload A, wallet signs payload B.
+**Repro:** Patch `handleConfirm()` in DevTools to mutate amount before approval — request signs the mutated value.
+**Fix direction:** Background must hold the canonical params; popup should only send `{requestId, decision: "approve"|"reject"}` and never echo params back.
+
+---
+
+## P1 — High
+
+### P1-1. Origin allowlist regex is too permissive
+**File:** `public/background.js:13-17`
+**Issue:** Pattern `/^https:\/\/.+$/` matches **any** HTTPS host. `evil.attacker.com` is treated identically to `app.legitimate.com`.
+**Fix direction:** Per-origin user consent table; track first-approval origin and require explicit re-prompt for new ones.
+
+### P1-2. 24-hour `getAddresses` cache enables replay across origins
+**File:** `public/background.js:489-508`
+**Issue:** Cache key is origin only; no nonce, no per-request timestamp. Two tabs on same origin (or origins sharing a cached entry through any bug) get identical responses without user interaction for 24h.
+**Fix direction:** Cache key = `(origin, sessionId)`; require explicit re-prompt if active wallet/network changed.
+
+### P1-3. PIN-only encryption path (device secret optional)
+**File:** `src/utils/security/encryption.ts:108-119`
+**Issue:** `encryptWithPIN(data, pin, deviceSecret?)` accepts `undefined` secret → 6-digit PIN = 10⁶ entropy ≈ crackable in seconds offline even at 600k PBKDF2 iterations.
+**Fix direction:** Mandate device secret at runtime; throw on missing secret.
+
+### P1-4. Silent approval drop on request-ID mismatch
+**File:** `public/background.js:337-349`
+**Issue:** `handleDappApprove()` returns silently on ID mismatch; popup believes approval succeeded; dApp eventually times out.
+**Fix direction:** Send rejection response back to popup so the UI can surface the error.
+
+### P1-5. UnlockView lockout dead-end (issue #18, expanded)
+**File:** `src/views/UnlockView.vue:38, 124`
+**Issue:** After lockout (30s/2m/10m/1h) expires, UI does not auto-refresh `attemptsRemaining`; user must reload extension. Already tracked as issue #18, but the audit confirms there's no countdown timer or auto-recover.
+**Fix direction:** Watch `LockoutManager` state with reactive timer; re-enable PinInput when expired.
+
+### P1-6. Double-broadcast race on slow network
+**File:** `src/views/SendView.vue:327-355`, `src/views/TxResultView.vue:131-158`
+**Issue:** If popup closes between `transitionToSubmitting()` (sets `status="pending"`) and `transferStx()` resolution, draft is left in `pending` with no txid. Reopen → TxResultView mounts fresh polling loop while the original network call may still be in flight.
+**Fix direction:** Persist a `broadcasting=true` lock + idempotency key in the draft; require explicit retry rather than auto-resume.
+
+### P1-7. Draft singleton leaks across wallet/network switches
+**File:** `src/composables/useTxDraft.ts:98`
+**Issue:** Module-level `reactive` state. Switching network/wallet does not clear the draft. Recipient validated against network A can survive into network B's flow.
+**Fix direction:** Clear draft on network change and on wallet switch (subscribe to those store events).
+
+### P1-8. WASM-unsafe-eval in CSP
+**File:** `public/manifest.json:16`
+**Issue:** Required by `@stacks/transactions`. Expands attack surface if any extension JS is compromised — WASM can read raw memory regions during signing.
+**Fix direction:** Document the dependency; track upstream removal; consider sandboxing signing into a dedicated worker context.
+
+---
+
+## P2 — Medium
+
+| # | File:line | Issue |
+|---|---|---|
+| P2-1 | `Confirmation.vue:115-116` vs `:486` | Message truncation mismatch: 100-char summary vs untruncated detail panel — phishing via hidden suffix |
+| P2-2 | `background.js:35-38` | Rate limiter resets if elapsed > 60s, exploitable with timed dummy request to double effective limit |
+| P2-3 | `public/content.js:31-59` | Page scripts can fire `CustomEvent('stackswallet_request')` on `document` — no script-origin distinction |
+| P2-4 | `vault.ts:408` | Single-pass zero-overwrite of legacy data insufficient against forensic recovery |
+| P2-5 | `session.ts:280-314` | Auto-lock timer resets on `mousemove`/`scroll` (passive) — leaving popup focused defeats 5-min lock indefinitely |
+| P2-6 | `session.ts:68-71` | Snapshot-mode mnemonic in localStorage relies on `__DEV__` dead-code elimination — single env-var flip exposes it |
+| P2-7 | `session.ts:187-224` | `MAX_ATTEMPTS_BEFORE_LOCKOUT = 3` permits ~24 attempts/hour across re-locks; consider 2 + immediate delay |
+| P2-8 | `session.ts:302-314` | Activity-listener race vs auto-lock timer can clear timeout 1ms after unlock starts |
+| P2-9 | `SendView.vue:288-310` | `route.query.confirmed` watch lacks debounce; double-fire possible across rapid back/forward |
+| P2-10 | `SendView.vue:454` | Memo `maxlength=34` HTML-only — paste truncates silently with no UX cue |
+| P2-11 | `ManageWalletsView.vue:91-98` | Wallet switch always pushes `/unlock` even if already unlocked → flash of unlock screen |
+| P2-12 | `AddWalletView.vue:132-139` | Imported mnemonic cleared from `history.state` once; back/forward can re-expose if browser keeps state |
+
+---
+
+## P3 — Low / Hardening
+
+| # | File:line | Note |
+|---|---|---|
+| P3-1 | `encryption.ts:14` | PBKDF2 = 600k (NIST minimum). Add `version` field for future rotation to 1M+. |
+| P3-2 | `encryption.ts:15` | Salt = 16 bytes. Consider 32 for quantum-margin. |
+| P3-3 | `TxDetailRow.vue:18-22` | Clipboard never auto-cleared after address copy; document or implement TTL clear. |
+| P3-4 | `device-secret.ts:17` | `cachedSecret` not zeroed on `clear()`. |
+| P3-5 | `vault.ts` | Wallet metadata (names, IDs, createdAt) stored unencrypted in `chrome.storage.local`. |
+| P3-6 | `UnlockView.vue:44-48` | `showBiometricOption` hardcoded `false`; remove dead prop or implement. |
+| P3-7 | `AccountsView.vue:134-165` | Multi-tab race on `setAccountCount` can exceed `MAX_ACCOUNTS=10`. |
+| P3-8 | `AddNetworkView.vue:80-108` | RPC test pings `/v2/info` only; no fallback. Accepts `http://localhost` without auth check. |
+| P3-9 | `ManageWalletsView.vue:120-136` | Rename allows whitespace-only after pre-trim guard slips through. |
+
+---
+
+## Verified OK / Defense-in-Depth
+
+**Cryptography**
+- AES-256-GCM with unique IV per encryption
+- Unique salt per vault entry (rainbow tables defeated)
+- Auth tag verified by Web Crypto on decrypt
+- PIN+device-secret combined for ~264-bit effective entropy when secret present
+
+**Session**
+- Failed unlock leaves wallet locked (no state leakage)
+- Lockout escalation 30s → 2m → 10m → 1h
+- `getMnemonic()` guard returns null when locked
+- Activity listeners cleaned up via scope
+
+**dApp Boundary**
+- `event.origin === window.location.origin` checked in `injection.js:66`
+- `targetOrigin` specified in `postMessage` (no `*`)
+- JSON-RPC fields validated in `content.js`
+- 55s background timeout < 60s injection timeout (no orphans)
+- Sender ID verified (`sender.id === chrome.runtime.id`)
+- Rate limit 30 req/min/origin
+
+**State / Routing**
+- Route guards: `/send`, `/confirm-tx`, `/tx-result` redirect when locked / draft missing
+- Anti double-submit via `transitionToSubmitting()` status guard (tested in `useTxDraft.test.ts`)
+- `onUnmounted` polling cleanup in TxResultView
+- Draft persists across popup close (intentional for resume)
+- Test/Dev network chip on all critical surfaces
+
+**Code Hygiene**
+- `logger.ts` redacts mnemonic/PIN/privateKey patterns when DEBUG enabled
+- No `innerHTML` / `eval` in templates or JS
+- Legacy migration with version tracking
+
+---
+
+## Recommended Action Plan
+
+### Before mainnet (must-fix)
+1. **P0-1** Mnemonic → SecureBuffer migration (largest engineering effort)
+2. **P0-2** Move Hiro API key behind a proxy
+3. **P0-3** Background-canonical params; popup sends decisions only
+4. **P1-1** Per-origin consent model
+5. **P1-3** Mandate device secret in `encryptWithPIN`
+6. **P1-5** Fix lockout auto-recover (issue #18 — already on backlog)
+
+### Before next feature release (should-fix)
+7. **P1-2** Replace 24h address cache with session-bound consent
+8. **P1-4** Surface approval rejection on ID mismatch
+9. **P1-6** Idempotency lock on broadcast
+10. **P1-7** Clear draft on wallet/network switch
+11. **P2-1, P2-3, P2-5** Truncation mismatch, page-script forge, passive-event lock reset
+
+### Hardening backlog
+- All P2 + P3 items as time permits
+- Consider: dedicated signing worker, encrypted metadata, biometric removal or implementation
+
+---
+
+## Coverage notes
+
+- **Audited:** 21 views, security primitives, background/content/injection, message routing, router, stores
+- **Not audited (out of scope):** Smart-contract Clarity tests, BTC adapter internals, Stacks SDK upstream
+- **Tooling assumption:** Findings derived from static reading of `main` at HEAD `472000e`. No runtime fuzzing performed — recommend follow-up with Playwright + bad-fixture corpus for confirmed exploits.

--- a/denvault-extension/package.json
+++ b/denvault-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "contract:check": "npx tsx scripts/ui-contract-check.ts",
     "verify": "run-s lint type-check build contract:check",
     "verify:production": "bash scripts/verify-production.sh",
-    "release:zip": "rm -f ../denvault-v1.1.0.zip && cd dist && zip -r ../../denvault-v1.1.0.zip . -x '*.DS_Store' && cd .. && echo 'Created denvault-v1.1.0.zip'"
+    "release:zip": "bash scripts/release-zip.sh"
   },
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.2.0",

--- a/denvault-extension/public/background.js
+++ b/denvault-extension/public/background.js
@@ -29,7 +29,9 @@ const DEBUG_QUEUE = false;
 
 function logQueue(...args) {
   if (DEBUG_QUEUE) {
-    console.log("[Queue]", ...args);
+    // Debug level, not info: this is developer diagnostics and must not
+    // read as production logging in the shipped service worker.
+    console.debug("[Queue]", ...args);
   }
 }
 

--- a/denvault-extension/public/background.js
+++ b/denvault-extension/public/background.js
@@ -280,6 +280,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       handleDappReject(message.id, message.error);
       return;
 
+    case "GET_ACTIVE_REQUEST":
+      // P0-3: Popup fetches canonical request params from background
+      // before signing. Background is the single source of truth.
+      handleGetActiveRequest(message.requestId, sendResponse);
+      return true; // Keep channel open for async sendResponse
+
     case "GET_QUEUE_STATUS":
       sendResponse(getQueueStatus());
       return true; // Keep channel open for sendResponse
@@ -289,6 +295,74 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return true; // Keep channel open for async
   }
 });
+
+/**
+ * P0-3: Return the canonical params of the active request to the popup.
+ * The popup MUST use these params (not its own props.payload) when
+ * constructing a signature, so a tampered popup payload cannot escape
+ * the user's approved scope.
+ *
+ * @param {string} requestId - Request ID the popup believes is active
+ * @param {(response: object) => void} sendResponse - Async callback
+ */
+function handleGetActiveRequest(requestId, sendResponse) {
+  if (!activeRequest) {
+    sendResponse({
+      ok: false,
+      error: {
+        code: 4002,
+        message: "No active request — request expired or no longer active",
+      },
+    });
+    return;
+  }
+
+  if (activeRequest.id !== requestId) {
+    sendResponse({
+      ok: false,
+      error: {
+        code: 4002,
+        message: "Request ID mismatch — request expired or no longer active",
+      },
+    });
+    return;
+  }
+
+  sendResponse({
+    ok: true,
+    request: {
+      id: activeRequest.id,
+      method: activeRequest.method,
+      params: activeRequest.params,
+      origin: activeRequest.origin,
+    },
+  });
+}
+
+/**
+ * P1-4: Notify the popup that an approval/rejection it just sent is
+ * stale (no active request, ID mismatch, or already resolved). Without
+ * this, the popup would believe its decision succeeded while the dApp
+ * silently times out.
+ *
+ * @param {string} requestId - The (stale) ID the popup sent
+ * @param {string} message - Human-readable reason
+ */
+function notifyPopupResponseError(requestId, message) {
+  console.warn("[StacksWallet] Popup decision rejected:", message, requestId);
+  chrome.runtime
+    .sendMessage({
+      type: "DAPP_RESPONSE_ERROR",
+      requestId: requestId,
+      error: {
+        code: 4002,
+        message: message,
+      },
+    })
+    .catch(() => {
+      // Popup may have already closed; nothing to do.
+    });
+}
 
 /**
  * V80: Open side panel with fallback to full page
@@ -330,19 +404,42 @@ async function handleOpenSidePanel(sender, sendResponse) {
 }
 
 /**
- * Handle approval from UI
+ * Handle approval from UI.
+ *
+ * Validates that the popup's decision matches the active request and
+ * surfaces an explicit DAPP_RESPONSE_ERROR on any mismatch (P1-4).
+ *
+ * NOTE on P0-3 residual risk: the popup still constructs the signed
+ * `result` (the mnemonic lives in the popup session). This handler
+ * forwards that result to the dApp tab. Defense-in-depth guarantee
+ * provided here: the popup's `requestId` MUST match `activeRequest.id`,
+ * so a stale or replayed approval cannot silently hijack a different
+ * request. Future hardening: move signing to the background so
+ * `activeRequest.params` becomes the only source of payload bytes.
+ *
  * @param {string} id - Request ID
  * @param {object} result - Result to return
  */
 function handleDappApprove(id, result) {
-  if (!activeRequest || activeRequest.id !== id) {
-    console.warn("[StacksWallet] Approve for unknown request:", id);
+  if (!activeRequest) {
+    notifyPopupResponseError(
+      id,
+      "No active request — request expired or no longer active"
+    );
+    return;
+  }
+
+  if (activeRequest.id !== id) {
+    notifyPopupResponseError(
+      id,
+      "Request ID mismatch — request expired or no longer active"
+    );
     return;
   }
 
   activeRequest.respond({
     jsonrpc: "2.0",
-    id: id,
+    id: activeRequest.id,
     result: result,
   });
 
@@ -350,19 +447,32 @@ function handleDappApprove(id, result) {
 }
 
 /**
- * Handle rejection from UI
+ * Handle rejection from UI. Mirrors handleDappApprove's validation so
+ * stale rejects produce explicit feedback instead of silently timing out.
+ *
  * @param {string} id - Request ID
  * @param {object} [error] - Optional error details
  */
 function handleDappReject(id, error) {
-  if (!activeRequest || activeRequest.id !== id) {
-    console.warn("[StacksWallet] Reject for unknown request:", id);
+  if (!activeRequest) {
+    notifyPopupResponseError(
+      id,
+      "No active request — request expired or no longer active"
+    );
+    return;
+  }
+
+  if (activeRequest.id !== id) {
+    notifyPopupResponseError(
+      id,
+      "Request ID mismatch — request expired or no longer active"
+    );
     return;
   }
 
   activeRequest.respond({
     jsonrpc: "2.0",
-    id: id,
+    id: activeRequest.id,
     error: error || {
       code: 4001,
       message: "User rejected the request",

--- a/denvault-extension/public/manifest.json
+++ b/denvault-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "DenVault",
   "short_name": "DenVault",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "DenVault - Your Bitcoin Layer 2 wallet for the Stacks ecosystem.",
   "action": {
     "default_title": "DenVault",

--- a/denvault-extension/scripts/release-zip.sh
+++ b/denvault-extension/scripts/release-zip.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Package dist/ for the Chrome Web Store.
+#
+# The version comes from public/manifest.json — the file CWS actually
+# reads — so the artifact name can never drift from what is inside it.
+# The previous script hardcoded 1.1.0, which is how a stale ZIP survived
+# three months of changes.
+
+cd "$(dirname "$0")/.."
+
+if [ ! -f dist/manifest.json ]; then
+  echo "FAIL: dist/ not built. Run 'pnpm verify:production' first."
+  exit 1
+fi
+
+VERSION=$(node -p "require('./public/manifest.json').version")
+DIST_VERSION=$(node -p "require('./dist/manifest.json').version")
+
+if [ "$VERSION" != "$DIST_VERSION" ]; then
+  echo "FAIL: dist/ was built from version $DIST_VERSION, manifest says $VERSION"
+  echo "      Rebuild before packaging."
+  exit 1
+fi
+
+ZIP="../denvault-v${VERSION}.zip"
+
+rm -f "$ZIP"
+(cd dist && zip -rq "../$ZIP" . -x '*.DS_Store')
+
+echo "Created denvault-v${VERSION}.zip ($(du -h "$ZIP" | cut -f1))"

--- a/denvault-extension/scripts/verify-production.sh
+++ b/denvault-extension/scripts/verify-production.sh
@@ -5,11 +5,11 @@ echo "=== DenVault Production Build Verification ==="
 echo ""
 
 # Step 1: Build
-echo "[1/4] Building production bundle..."
+echo "[1/5] Building production bundle..."
 pnpm build-only
 
 # Step 2: Check for snapshot mode backdoor
-echo "[2/4] Checking for snapshot mode strings in dist/..."
+echo "[2/5] Checking for snapshot mode strings in dist/..."
 if grep -r "__UI_SNAPSHOT_MODE__" dist/; then
   echo "FAIL: Snapshot mode string found in production build"
   exit 1
@@ -17,20 +17,49 @@ fi
 echo "  OK: No snapshot mode strings found"
 
 # Step 3: Check for devLog calls
-echo "[3/4] Checking for devLog calls in dist/..."
+echo "[3/5] Checking for devLog calls in dist/..."
 if grep -r "devLog" dist/; then
   echo "WARN: devLog found in production build (non-blocking)"
 fi
 echo "  OK: devLog check complete"
 
-# Step 4: Check for console.log (optional warning)
-echo "[4/4] Checking for console.log in dist/..."
-CONSOLE_COUNT=$(grep -r "console\.log" dist/ | wc -l | tr -d ' ')
-if [ "$CONSOLE_COUNT" -gt 0 ]; then
-  echo "  WARN: $CONSOLE_COUNT console.log occurrences found in dist/"
+# Step 4: Check for console.log
+# Split by ownership: our own extension scripts are copied verbatim from
+# public/ and must be clean, while bundled dependencies (@noble/hashes
+# logs a digest fallback) are outside our control and only reported.
+echo "[4/5] Checking for console.log in dist/..."
+OWNED_CONSOLE=0
+for f in dist/background.js dist/content.js dist/injection.js; do
+  [ -f "$f" ] || continue
+  COUNT=$(grep -c "console\.log" "$f" || true)
+  if [ "$COUNT" -gt 0 ]; then
+    echo "  FAIL: $COUNT console.log in $f"
+    OWNED_CONSOLE=$((OWNED_CONSOLE + COUNT))
+  fi
+done
+if [ "$OWNED_CONSOLE" -gt 0 ]; then
+  echo "FAIL: console.log found in extension-owned scripts"
+  exit 1
+fi
+VENDOR_CONSOLE=$(grep -r "console\.log" dist/ | wc -l | tr -d ' ')
+if [ "$VENDOR_CONSOLE" -gt 0 ]; then
+  echo "  OK: extension scripts clean ($VENDOR_CONSOLE occurrence(s) in bundled deps)"
 else
   echo "  OK: No console.log found"
 fi
+
+# Step 5: Check the Hiro platform API key never reaches the bundle.
+# The key is only used on the devnet branch (src/utils/balance/index.ts);
+# mainnet and testnet hit public endpoints. Building with a .env that
+# carries the key would embed it in plaintext, so fail hard on the URL
+# shape that only exists when the key is compiled in.
+echo "[5/5] Checking for embedded Hiro API key in dist/..."
+if grep -rq "api\.platform\.hiro\.so/v1/ext/" dist/; then
+  echo "FAIL: Hiro platform API key embedded in production build"
+  echo "      Rebuild without VITE_PLATFORM_HIRO_API_KEY set."
+  exit 1
+fi
+echo "  OK: No embedded Hiro API key"
 
 echo ""
 echo "=== Verification Complete ==="

--- a/denvault-extension/src/components/Confirmation.vue
+++ b/denvault-extension/src/components/Confirmation.vue
@@ -31,7 +31,7 @@ import "@/components/ui"; // Button used in template
 import { sessionManager } from "@/utils/security/session";
 import { secureLog, secureWarn } from "@/utils/security/logger";
 import { emitTxSignRequested, emitTxSignResult } from "@/denlabs/emit";
-import { fetchCanonicalRequest } from "@/composables/useCanonicalRequest";
+import { fetchCanonicalRequest, resolveDisplayPayload } from "@/composables/useCanonicalRequest";
 
 const isUnlocked = ref(false);
 const pinError = ref("");
@@ -56,12 +56,22 @@ const props = defineProps<{
   requestId?: string;
 }>();
 
+/**
+ * H1: every rendered field reads from here, never from `props.payload`.
+ * In queue mode this holds background's canonical params, so what the
+ * user reviews is byte-for-byte what handleConfirm signs. Until the
+ * fetch resolves (and in legacy URL mode) it falls back to the local
+ * payload, which is the only source available there.
+ */
+const canonicalPayload = ref<JsonRpcRequest | null>(null);
+const displayPayload = computed<JsonRpcRequest>(() => canonicalPayload.value ?? props.payload);
+
 onBeforeMount(() => {
   // Check if session is already unlocked
   isUnlocked.value = !sessionManager.isLocked;
 });
 
-onMounted(() => {
+onMounted(async () => {
   // DenLabs: Emit TX sign requested event
   txSignStartTime.value = Date.now();
   const walletId = sessionManager.activeWalletId || "unknown";
@@ -75,6 +85,21 @@ onMounted(() => {
   // P1-4: Subscribe to explicit error feedback from background (queue mode only).
   if (props.isQueueMode && typeof chrome !== "undefined" && chrome.runtime?.onMessage) {
     chrome.runtime.onMessage.addListener(handleResponseError);
+  }
+
+  // H1: pull the canonical params so the review screen renders the same
+  // bytes that will be signed.
+  const display = await resolveDisplayPayload({
+    payload: props.payload,
+    isQueueMode: props.isQueueMode,
+    requestId: props.requestId,
+  });
+  if (display.source === "canonical") {
+    canonicalPayload.value = display.payload;
+  } else if (props.isQueueMode) {
+    secureWarn("Canonical request unavailable for display; rendering local payload", {
+      requestId: props.requestId,
+    });
   }
 });
 
@@ -113,14 +138,14 @@ const methodDescription = computed(() => {
     signPsbt: "Sign PSBT (Bitcoin)",
     sendTransfer: "Send transfer",
   };
-  return descriptions[props.payload.method] || props.payload.method;
+  return descriptions[displayPayload.value.method] || displayPayload.value.method;
 });
 
 // Format params for display
 const formattedParams = computed(() => {
-  if (!props.payload.params) return null;
+  if (!displayPayload.value.params) return null;
 
-  const params = props.payload.params as Record<string, unknown>;
+  const params = displayPayload.value.params as Record<string, unknown>;
   const formatted: Record<string, string> = {};
 
   // Show relevant fields based on method
@@ -151,7 +176,7 @@ const formattedParams = computed(() => {
   if (params.recipient) {
     formatted["Recipient"] = String(params.recipient);
   }
-  if (params.name && props.payload.method === "stx_deployContract") {
+  if (params.name && displayPayload.value.method === "stx_deployContract") {
     formatted["Contract Name"] = String(params.name);
   }
   if (params.clarityCode) {
@@ -169,7 +194,7 @@ const formattedParams = computed(() => {
 
 // Dynamic subtitle per method type
 const methodSubtitle = computed(() => {
-  const method = props.payload?.method;
+  const method = displayPayload.value?.method;
   switch (method) {
     case "getAddresses":
     case "stx_getAddresses":
@@ -193,7 +218,7 @@ const methodSubtitle = computed(() => {
 
 // Show account selector for methods that operate on a single account
 const showAccountSelector = computed(() => {
-  const method = props.payload?.method;
+  const method = displayPayload.value?.method;
   return method !== "getAddresses" && method !== "stx_getAddresses" && method !== "stx_getAccounts";
 });
 
@@ -532,7 +557,7 @@ function handleReject(reason?: string) {
             <polyline points="6 9 12 15 18 9"/>
           </svg>
         </summary>
-        <pre class="raw-payload" data-roi="confirm-details-panel">{{ JSON.stringify(props.payload, null, 2) }}</pre>
+        <pre class="raw-payload" data-roi="confirm-details-panel">{{ JSON.stringify(displayPayload, null, 2) }}</pre>
       </details>
 
       <!-- PIN input if not unlocked -->

--- a/denvault-extension/src/components/Confirmation.vue
+++ b/denvault-extension/src/components/Confirmation.vue
@@ -13,7 +13,7 @@
  *
  * Trust-critical flow: Users approve dApp requests here.
  */
-import { onBeforeMount, onMounted, ref, computed } from "vue";
+import { onBeforeMount, onBeforeUnmount, onMounted, ref, computed } from "vue";
 import {
   handleSignMessage,
   handleGetAddresses,
@@ -31,6 +31,7 @@ import "@/components/ui"; // Button used in template
 import { sessionManager } from "@/utils/security/session";
 import { secureLog, secureWarn } from "@/utils/security/logger";
 import { emitTxSignRequested, emitTxSignResult } from "@/denlabs/emit";
+import { fetchCanonicalRequest } from "@/composables/useCanonicalRequest";
 
 const isUnlocked = ref(false);
 const pinError = ref("");
@@ -70,6 +71,17 @@ onMounted(() => {
     "stacks",
     props.origin || "unknown"
   );
+
+  // P1-4: Subscribe to explicit error feedback from background (queue mode only).
+  if (props.isQueueMode && typeof chrome !== "undefined" && chrome.runtime?.onMessage) {
+    chrome.runtime.onMessage.addListener(handleResponseError);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (props.isQueueMode && typeof chrome !== "undefined" && chrome.runtime?.onMessage) {
+    chrome.runtime.onMessage.removeListener(handleResponseError);
+  }
 });
 
 // Extract origin for display
@@ -204,6 +216,23 @@ function sendQueueReject(error?: { code: number; message: string }) {
   });
 }
 
+/**
+ * P1-4: Listener for explicit error responses from background. Fires
+ * when the popup's approve/reject decision was rejected (stale ID,
+ * already resolved, etc.). Without this the user would believe their
+ * decision succeeded while the dApp times out.
+ */
+function handleResponseError(message: unknown): undefined {
+  const m = message as { type?: string; requestId?: string; error?: { code: number; message: string } };
+  if (m?.type !== "DAPP_RESPONSE_ERROR") return undefined;
+  if (m.requestId && m.requestId !== props.requestId) return undefined;
+
+  isProcessing.value = false;
+  pinError.value = m.error?.message || "Request error";
+  secureWarn("Background rejected popup decision", { error: m.error });
+  return undefined;
+}
+
 // Close window/tab based on context (popup vs full-page)
 function closeWindow() {
   // Full-page mode: viewport is larger than popup dimensions
@@ -255,27 +284,47 @@ async function handleConfirm() {
 
   const accountIndex = selectedAccountIndex.value;
 
+  // P0-3: In queue mode, the canonical params live in background's
+  // activeRequest. Fetch them now and sign against THOSE bytes — never
+  // against props.payload, which a tampered popup could mutate between
+  // display and approval. Legacy URL mode keeps using props.payload
+  // because there is no background queue entry to consult.
+  let signingPayload: JsonRpcRequest = props.payload;
+  if (props.isQueueMode) {
+    const canonical = await fetchCanonicalRequest(props.requestId);
+    if (!canonical) {
+      secureWarn("Canonical request unavailable; aborting approve", {
+        requestId: props.requestId,
+      });
+      isProcessing.value = false;
+      pinError.value = "Request expired or no longer active";
+      handleReject("Request expired or no longer active");
+      return;
+    }
+    signingPayload = canonical;
+  }
+
   try {
-    switch (props.payload.method) {
+    switch (signingPayload.method) {
       case "getAddresses":
       case "stx_getAddresses":
       case "stx_getAccounts":
-        result = await handleGetAddresses(props.payload, mnemonic, accountIndex);
+        result = await handleGetAddresses(signingPayload, mnemonic, accountIndex);
         break;
       case "stx_signMessage":
-        result = await handleSignMessage(props.payload, mnemonic, accountIndex);
+        result = await handleSignMessage(signingPayload, mnemonic, accountIndex);
         break;
       case "stx_callContract":
-        result = await handleCallContract(props.payload, mnemonic, accountIndex);
+        result = await handleCallContract(signingPayload, mnemonic, accountIndex);
         break;
       case "stx_transferStx":
-        result = await handleTransferStx(props.payload, mnemonic, accountIndex);
+        result = await handleTransferStx(signingPayload, mnemonic, accountIndex);
         break;
       case "stx_signStructuredMessage":
-        result = await handleSignStructuredData(props.payload, mnemonic, accountIndex);
+        result = await handleSignStructuredData(signingPayload, mnemonic, accountIndex);
         break;
       case "stx_deployContract":
-        result = await handleDeployContract(props.payload, mnemonic, accountIndex);
+        result = await handleDeployContract(signingPayload, mnemonic, accountIndex);
         break;
       case "stx_transferSip10Ft":
         // TODO: implement
@@ -290,7 +339,7 @@ async function handleConfirm() {
         // TODO: implement
         break;
       default:
-        secureWarn("Unknown method", { method: props.payload.method });
+        secureWarn("Unknown method", { method: signingPayload.method });
         break;
     }
 
@@ -301,7 +350,7 @@ async function handleConfirm() {
       } else {
         await chrome.tabs.sendMessage(parseInt(props.tabId), result.data);
       }
-      secureLog("Response sent successfully", { method: props.payload.method, queueMode: props.isQueueMode });
+      secureLog("Response sent successfully", { method: signingPayload.method, queueMode: props.isQueueMode });
 
       // DenLabs: Emit TX sign result (approved)
       const walletId = sessionManager.activeWalletId || "unknown";
@@ -315,7 +364,7 @@ async function handleConfirm() {
       );
 
       // Cache getAddresses response for auto-approval
-      if (props.payload.method === "getAddresses" || props.payload.method === "stx_getAddresses" || props.payload.method === "stx_getAccounts") {
+      if (signingPayload.method === "getAddresses" || signingPayload.method === "stx_getAddresses" || signingPayload.method === "stx_getAccounts") {
         try {
           const cacheKey = `approved_${props.origin}`;
           await chrome.storage.session.set({ [cacheKey]: result.data });
@@ -331,7 +380,7 @@ async function handleConfirm() {
           code: -32603,
           message: "Internal Error",
         },
-        id: props.payload.id,
+        id: signingPayload.id,
       };
       if (props.isQueueMode) {
         sendQueueReject({ code: -32603, message: "Internal Error" });
@@ -363,7 +412,7 @@ async function handleConfirm() {
           code: -32603,
           message: errorMsg,
         },
-        id: props.payload.id,
+        id: signingPayload.id,
       });
     }
 

--- a/denvault-extension/src/composables/useCanonicalRequest.test.ts
+++ b/denvault-extension/src/composables/useCanonicalRequest.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the canonical-params fetcher (P0-3 popup-side guard).
+ *
+ * These tests prove that the popup signs against background's
+ * activeRequest.params, NOT against a (possibly tampered) `props.payload`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fetchCanonicalRequest } from "./useCanonicalRequest";
+
+describe("useCanonicalRequest.fetchCanonicalRequest", () => {
+  let sendMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendMessage = vi.fn();
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      runtime: { sendMessage },
+    };
+  });
+
+  it("returns the canonical JsonRpcRequest when background ack is ok", async () => {
+    sendMessage.mockResolvedValueOnce({
+      ok: true,
+      request: {
+        id: "req-1",
+        method: "stx_transferStx",
+        params: { recipient: "ST_CANONICAL", amount: "1000000" },
+        origin: "https://app.example.com",
+      },
+    });
+
+    const result = await fetchCanonicalRequest("req-1");
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: "GET_ACTIVE_REQUEST",
+      requestId: "req-1",
+    });
+    expect(result).toEqual({
+      jsonrpc: "2.0",
+      id: "req-1",
+      method: "stx_transferStx",
+      params: { recipient: "ST_CANONICAL", amount: "1000000" },
+    });
+  });
+
+  it("returns canonical params even when caller supplies a tampered payload locally", async () => {
+    // Simulate a scenario where the popup's local payload was mutated to
+    // a different recipient/amount, but background still holds the original.
+    const tamperedPopupParams = {
+      recipient: "ST_ATTACKER",
+      amount: "999999999",
+    };
+
+    sendMessage.mockResolvedValueOnce({
+      ok: true,
+      request: {
+        id: "req-2",
+        method: "stx_transferStx",
+        params: { recipient: "ST_VICTIM_APPROVED", amount: "100" },
+        origin: "https://legit.example.com",
+      },
+    });
+
+    const canonical = await fetchCanonicalRequest("req-2");
+
+    // Whatever the popup believes locally, signing must use these params.
+    expect(canonical?.params).toEqual({
+      recipient: "ST_VICTIM_APPROVED",
+      amount: "100",
+    });
+    // And specifically NOT the tampered values.
+    expect(canonical?.params).not.toEqual(tamperedPopupParams);
+  });
+
+  it("returns null when background reports ok:false", async () => {
+    sendMessage.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 4002, message: "Request expired or no longer active" },
+    });
+
+    const result = await fetchCanonicalRequest("req-stale");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when background returns a different request id", async () => {
+    // Defense in depth: background should never return mismatched id,
+    // but if it did, the popup must reject the response.
+    sendMessage.mockResolvedValueOnce({
+      ok: true,
+      request: {
+        id: "req-OTHER",
+        method: "stx_signMessage",
+        params: { message: "evil" },
+      },
+    });
+
+    const result = await fetchCanonicalRequest("req-asked");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when requestId is empty", async () => {
+    const result = await fetchCanonicalRequest(undefined);
+    expect(result).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns null when chrome runtime is unavailable", async () => {
+    (globalThis as unknown as { chrome: unknown }).chrome = undefined;
+    const result = await fetchCanonicalRequest("req-1");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when sendMessage throws (popup-background channel torn)", async () => {
+    sendMessage.mockRejectedValueOnce(new Error("Channel closed"));
+    const result = await fetchCanonicalRequest("req-broken");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when background returns no response (undefined)", async () => {
+    sendMessage.mockResolvedValueOnce(undefined);
+    const result = await fetchCanonicalRequest("req-1");
+    expect(result).toBeNull();
+  });
+});

--- a/denvault-extension/src/composables/useCanonicalRequest.test.ts
+++ b/denvault-extension/src/composables/useCanonicalRequest.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { fetchCanonicalRequest } from "./useCanonicalRequest";
+import { fetchCanonicalRequest, resolveDisplayPayload } from "./useCanonicalRequest";
+import type { JsonRpcRequest } from "@/utils/types";
 
 describe("useCanonicalRequest.fetchCanonicalRequest", () => {
   let sendMessage: ReturnType<typeof vi.fn>;
@@ -120,5 +121,92 @@ describe("useCanonicalRequest.fetchCanonicalRequest", () => {
     sendMessage.mockResolvedValueOnce(undefined);
     const result = await fetchCanonicalRequest("req-1");
     expect(result).toBeNull();
+  });
+});
+
+/**
+ * H1: the display layer must read the same canonical bytes the signer
+ * uses. Before this, signing used the canonical payload while every
+ * rendered field still read `props.payload` — so a mutated popup payload
+ * meant the user saw one transaction and signed another.
+ */
+describe("useCanonicalRequest.resolveDisplayPayload", () => {
+  let sendMessage: ReturnType<typeof vi.fn>;
+
+  const tampered: JsonRpcRequest = {
+    jsonrpc: "2.0",
+    id: "req-1",
+    method: "stx_transferStx",
+    params: { recipient: "ST_ATTACKER", amount: "999999999" },
+  } as JsonRpcRequest;
+
+  beforeEach(() => {
+    sendMessage = vi.fn();
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      runtime: { sendMessage },
+    };
+  });
+
+  it("renders the canonical payload in queue mode, not the local one", async () => {
+    sendMessage.mockResolvedValueOnce({
+      ok: true,
+      request: {
+        id: "req-1",
+        method: "stx_transferStx",
+        params: { recipient: "ST_VICTIM_APPROVED", amount: "100" },
+      },
+    });
+
+    const result = await resolveDisplayPayload({
+      payload: tampered,
+      isQueueMode: true,
+      requestId: "req-1",
+    });
+
+    expect(result.source).toBe("canonical");
+    expect(result.payload.params).toEqual({
+      recipient: "ST_VICTIM_APPROVED",
+      amount: "100",
+    });
+    expect(result.payload.params).not.toEqual(tampered.params);
+  });
+
+  it("falls back to the local payload when the canonical is unavailable", async () => {
+    // Request already resolved or expired: nothing to render from
+    // background. Display degrades to the local payload, and handleConfirm
+    // still refuses to sign because its own fetch fails too.
+    sendMessage.mockResolvedValueOnce({ ok: false });
+
+    const result = await resolveDisplayPayload({
+      payload: tampered,
+      isQueueMode: true,
+      requestId: "req-1",
+    });
+
+    expect(result.source).toBe("local");
+    expect(result.payload).toBe(tampered);
+  });
+
+  it("uses the local payload without querying background in legacy URL mode", async () => {
+    const result = await resolveDisplayPayload({
+      payload: tampered,
+      isQueueMode: false,
+      requestId: undefined,
+    });
+
+    expect(result.source).toBe("local");
+    expect(result.payload).toBe(tampered);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("uses the local payload when queue mode has no request id", async () => {
+    const result = await resolveDisplayPayload({
+      payload: tampered,
+      isQueueMode: true,
+      requestId: undefined,
+    });
+
+    expect(result.source).toBe("local");
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/denvault-extension/src/composables/useCanonicalRequest.ts
+++ b/denvault-extension/src/composables/useCanonicalRequest.ts
@@ -1,0 +1,64 @@
+/**
+ * Canonical request fetcher (P0-3 mitigation).
+ *
+ * Background.js holds the single source of truth for the params of the
+ * active dApp request. The popup must source signing bytes from here,
+ * NEVER from `props.payload`, because the prop ref can be mutated
+ * between display and approval (XSS, race, compromised popup).
+ *
+ * Legacy URL-payload mode bypasses the queue and has no background
+ * counterpart; in that case this returns null and the caller should
+ * fall back to its local payload (still the only source available).
+ */
+
+import type { JsonRpcRequest } from "@/utils/types";
+
+export interface CanonicalRequest {
+  id: string;
+  method: string;
+  params: unknown;
+  origin?: string;
+}
+
+export type CanonicalResponse =
+  | { ok: true; request: CanonicalRequest }
+  | { ok: false; error?: { code: number; message: string } };
+
+/**
+ * Ask background.js for the canonical params of the active request.
+ *
+ * @param requestId - The id the popup believes is active. Background
+ *   verifies it matches activeRequest.id; on mismatch it returns
+ *   `{ ok: false }` and this function resolves to `null`.
+ * @returns A JsonRpcRequest reconstructed from canonical fields, or
+ *   `null` if no canonical request can be retrieved.
+ */
+export async function fetchCanonicalRequest(
+  requestId: string | undefined
+): Promise<JsonRpcRequest | null> {
+  if (!requestId) return null;
+  if (typeof chrome === "undefined" || !chrome.runtime?.sendMessage) {
+    return null;
+  }
+
+  try {
+    const response = (await chrome.runtime.sendMessage({
+      type: "GET_ACTIVE_REQUEST",
+      requestId,
+    })) as CanonicalResponse | undefined;
+
+    if (!response || !response.ok) return null;
+
+    const canonical = response.request;
+    if (canonical.id !== requestId) return null;
+
+    return {
+      jsonrpc: "2.0",
+      id: canonical.id,
+      method: canonical.method,
+      params: canonical.params,
+    } as JsonRpcRequest;
+  } catch {
+    return null;
+  }
+}

--- a/denvault-extension/src/composables/useCanonicalRequest.ts
+++ b/denvault-extension/src/composables/useCanonicalRequest.ts
@@ -62,3 +62,41 @@ export async function fetchCanonicalRequest(
     return null;
   }
 }
+
+/** Where the payload being rendered came from. */
+export type DisplaySource = "canonical" | "local";
+
+export interface DisplayPayload {
+  payload: JsonRpcRequest;
+  source: DisplaySource;
+}
+
+/**
+ * Resolve which payload the confirmation screen should render.
+ *
+ * Signing already sources its bytes from background (see
+ * `fetchCanonicalRequest`). The display must do the same, otherwise the
+ * user reviews `props.payload` while approving different bytes — the
+ * "see one thing, sign another" gap.
+ *
+ * Legacy URL mode has no background queue entry, so the local payload is
+ * the only source available and is returned as-is. In queue mode a failed
+ * fetch also degrades to the local payload: `handleConfirm` performs its
+ * own fetch and aborts, so nothing can be signed from that state.
+ */
+export async function resolveDisplayPayload(opts: {
+  payload: JsonRpcRequest;
+  isQueueMode?: boolean;
+  requestId?: string;
+}): Promise<DisplayPayload> {
+  if (!opts.isQueueMode || !opts.requestId) {
+    return { payload: opts.payload, source: "local" };
+  }
+
+  const canonical = await fetchCanonicalRequest(opts.requestId);
+  if (!canonical) {
+    return { payload: opts.payload, source: "local" };
+  }
+
+  return { payload: canonical, source: "canonical" };
+}

--- a/denvault-extension/src/composables/useLockoutCountdown.test.ts
+++ b/denvault-extension/src/composables/useLockoutCountdown.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the lockout countdown (issue #18).
+ *
+ * Before this, UnlockView showed "Too many attempts. Reset wallet to
+ * continue." and disabled the keypad terminally, so the only escape from
+ * a temporary lockout was destroying the wallet. LockoutManager already
+ * expires the lockout on its own; the UI just never observed it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { formatLockoutRemaining, useLockoutCountdown } from "./useLockoutCountdown";
+
+describe("formatLockoutRemaining", () => {
+  it("renders sub-minute lockouts as m:ss", () => {
+    expect(formatLockoutRemaining(30_000)).toBe("0:30");
+    expect(formatLockoutRemaining(1_000)).toBe("0:01");
+  });
+
+  it("rounds partial seconds up so the label never reads 0:00 while locked", () => {
+    expect(formatLockoutRemaining(1)).toBe("0:01");
+    expect(formatLockoutRemaining(29_400)).toBe("0:30");
+  });
+
+  it("renders the escalated durations", () => {
+    expect(formatLockoutRemaining(120_000)).toBe("2:00");
+    expect(formatLockoutRemaining(600_000)).toBe("10:00");
+    expect(formatLockoutRemaining(3_600_000)).toBe("1:00:00");
+  });
+
+  it("renders zero and negative input as 0:00", () => {
+    expect(formatLockoutRemaining(0)).toBe("0:00");
+    expect(formatLockoutRemaining(-5_000)).toBe("0:00");
+  });
+});
+
+describe("useLockoutCountdown", () => {
+  let now: number;
+  let lockedUntil: number;
+
+  /** Stand-in for sessionManager's lockout surface. */
+  const source = {
+    get isLockedOut() {
+      return now < lockedUntil;
+    },
+    get lockoutRemainingMs() {
+      return Math.max(0, lockedUntil - now);
+    },
+  };
+
+  function advance(ms: number) {
+    now += ms;
+    vi.advanceTimersByTime(ms);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    now = 0;
+    lockedUntil = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports not locked out when the session is free", () => {
+    const countdown = useLockoutCountdown(source);
+    countdown.start();
+
+    expect(countdown.isLockedOut.value).toBe(false);
+    expect(countdown.remainingLabel.value).toBe("0:00");
+    countdown.stop();
+  });
+
+  it("exposes the remaining time while locked out", () => {
+    lockedUntil = 30_000;
+    const countdown = useLockoutCountdown(source);
+    countdown.start();
+
+    expect(countdown.isLockedOut.value).toBe(true);
+    expect(countdown.remainingLabel.value).toBe("0:30");
+
+    advance(10_000);
+    expect(countdown.remainingLabel.value).toBe("0:20");
+
+    countdown.stop();
+  });
+
+  it("clears the lockout by itself once it expires", () => {
+    lockedUntil = 30_000;
+    const countdown = useLockoutCountdown(source);
+    countdown.start();
+
+    expect(countdown.isLockedOut.value).toBe(true);
+
+    advance(30_000);
+
+    // This is the fix: no user action, no wallet reset — the keypad
+    // comes back on its own.
+    expect(countdown.isLockedOut.value).toBe(false);
+    expect(countdown.remainingLabel.value).toBe("0:00");
+
+    countdown.stop();
+  });
+
+  it("stops ticking after the lockout expires", () => {
+    lockedUntil = 30_000;
+    const countdown = useLockoutCountdown(source);
+    countdown.start();
+
+    advance(30_000);
+    expect(vi.getTimerCount()).toBe(0);
+
+    countdown.stop();
+  });
+
+  it("stop() halts the timer while still locked out", () => {
+    lockedUntil = 60_000;
+    const countdown = useLockoutCountdown(source);
+    countdown.start();
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    countdown.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("start() is idempotent and does not stack timers", () => {
+    lockedUntil = 60_000;
+    const countdown = useLockoutCountdown(source);
+    countdown.start();
+    const timers = vi.getTimerCount();
+    countdown.start();
+
+    expect(vi.getTimerCount()).toBe(timers);
+    countdown.stop();
+  });
+
+  it("picks up a lockout that starts after the countdown was created", () => {
+    const countdown = useLockoutCountdown(source);
+    countdown.start();
+    expect(countdown.isLockedOut.value).toBe(false);
+
+    // A failed attempt trips the lockout; the view calls start() again.
+    lockedUntil = now + 120_000;
+    countdown.start();
+
+    expect(countdown.isLockedOut.value).toBe(true);
+    expect(countdown.remainingLabel.value).toBe("2:00");
+    countdown.stop();
+  });
+});

--- a/denvault-extension/src/composables/useLockoutCountdown.ts
+++ b/denvault-extension/src/composables/useLockoutCountdown.ts
@@ -1,0 +1,88 @@
+/**
+ * Lockout countdown (issue #18).
+ *
+ * `LockoutManager` already expires a lockout on its own — 30s, then 2min,
+ * 10min, 1hr. But nothing polled it, so the unlock screen stayed disabled
+ * forever and told the user to reset the wallet, destroying it over a
+ * temporary block.
+ *
+ * This polls the session's lockout surface on a timer, exposes the
+ * remaining time for display, and flips back to unlocked by itself the
+ * moment the block expires.
+ */
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+
+/** The slice of sessionManager this countdown observes. */
+export interface LockoutSource {
+  readonly isLockedOut: boolean;
+  readonly lockoutRemainingMs: number;
+}
+
+export interface LockoutCountdown {
+  isLockedOut: Ref<boolean>;
+  remainingMs: Ref<number>;
+  remainingLabel: ComputedRef<string>;
+  /** Sync now and keep ticking while locked out. Idempotent. */
+  start(): void;
+  /** Stop ticking. Safe to call when not running. */
+  stop(): void;
+}
+
+const DEFAULT_INTERVAL_MS = 500;
+
+/**
+ * Format a remaining duration for display.
+ *
+ * Seconds round up so the label never reads 0:00 while the user is still
+ * blocked. Durations of an hour or more get an h:mm:ss form.
+ */
+export function formatLockoutRemaining(ms: number): string {
+  if (ms <= 0) return "0:00";
+
+  const totalSeconds = Math.ceil(ms / 1000);
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const hours = Math.floor(totalMinutes / 60);
+
+  const paddedSeconds = String(seconds).padStart(2, "0");
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${paddedSeconds}`;
+  }
+  return `${minutes}:${paddedSeconds}`;
+}
+
+export function useLockoutCountdown(
+  source: LockoutSource,
+  options: { intervalMs?: number } = {}
+): LockoutCountdown {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+
+  const isLockedOut = ref(source.isLockedOut);
+  const remainingMs = ref(source.lockoutRemainingMs);
+  const remainingLabel = computed(() => formatLockoutRemaining(remainingMs.value));
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function stop(): void {
+    if (timer === null) return;
+    clearInterval(timer);
+    timer = null;
+  }
+
+  function sync(): void {
+    isLockedOut.value = source.isLockedOut;
+    remainingMs.value = source.lockoutRemainingMs;
+    // Nothing left to count: release the keypad and drop the timer.
+    if (!isLockedOut.value) stop();
+  }
+
+  function start(): void {
+    sync();
+    if (!isLockedOut.value || timer !== null) return;
+    timer = setInterval(sync, intervalMs);
+  }
+
+  return { isLockedOut, remainingMs, remainingLabel, start, stop };
+}

--- a/denvault-extension/src/test/background-queue.test.ts
+++ b/denvault-extension/src/test/background-queue.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Vitest harness for public/background.js
+ *
+ * Loads the service worker script in a sandboxed Function and exercises
+ * the message dispatcher with a mocked chrome.* API. Targets the contract
+ * between popup and background introduced for P0-3 (canonical params)
+ * and P1-4 (explicit mismatch error).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const BACKGROUND_PATH = resolve(__dirname, "../../public/background.js");
+const BACKGROUND_SOURCE = readFileSync(BACKGROUND_PATH, "utf-8");
+
+type Listener = (
+  message: unknown,
+  sender: unknown,
+  sendResponse: (response?: unknown) => void
+) => unknown;
+
+interface ChromeHarness {
+  messageListeners: Listener[];
+  windowsRemovedListeners: Array<(id: number) => void>;
+  tabsSendMessage: ReturnType<typeof vi.fn>;
+  runtimeSendMessage: ReturnType<typeof vi.fn>;
+  windowsCreate: ReturnType<typeof vi.fn>;
+  storageSessionGet: ReturnType<typeof vi.fn>;
+  storageSessionSet: ReturnType<typeof vi.fn>;
+}
+
+function installChromeMock(): ChromeHarness {
+  const messageListeners: Listener[] = [];
+  const windowsRemovedListeners: Array<(id: number) => void> = [];
+
+  const tabsSendMessage = vi.fn().mockResolvedValue(undefined);
+  const runtimeSendMessage = vi.fn().mockResolvedValue(undefined);
+  const windowsCreate = vi.fn().mockResolvedValue({ id: 99 });
+  const storageSessionGet = vi.fn().mockResolvedValue({});
+  const storageSessionSet = vi.fn().mockResolvedValue(undefined);
+
+  const chromeMock = {
+    runtime: {
+      id: "denvault-test",
+      getURL: (p: string) => `chrome-extension://test/${p}`,
+      sendMessage: runtimeSendMessage,
+      onMessage: {
+        addListener: (l: Listener) => {
+          messageListeners.push(l);
+        },
+        removeListener: vi.fn(),
+      },
+    },
+    tabs: {
+      sendMessage: tabsSendMessage,
+      query: vi.fn().mockResolvedValue([]),
+      create: vi.fn(),
+      remove: vi.fn(),
+      getCurrent: vi.fn(),
+    },
+    windows: {
+      create: windowsCreate,
+      get: vi.fn().mockResolvedValue({ id: 99 }),
+      update: vi.fn().mockResolvedValue({}),
+      onRemoved: {
+        addListener: (l: (id: number) => void) => {
+          windowsRemovedListeners.push(l);
+        },
+      },
+    },
+    storage: {
+      session: {
+        get: storageSessionGet,
+        set: storageSessionSet,
+        remove: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    sidePanel: {
+      setOptions: vi.fn().mockResolvedValue(undefined),
+      open: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+
+  (globalThis as unknown as { chrome: unknown }).chrome = chromeMock;
+
+  return {
+    messageListeners,
+    windowsRemovedListeners,
+    tabsSendMessage,
+    runtimeSendMessage,
+    windowsCreate,
+    storageSessionGet,
+    storageSessionSet,
+  };
+}
+
+function loadBackground(): void {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function(BACKGROUND_SOURCE)();
+}
+
+interface DispatchOptions {
+  id?: string;
+  method?: string;
+  params?: Record<string, unknown>;
+  origin?: string;
+  tabId?: number;
+}
+
+/**
+ * Simulate a dApp request reaching background via the content-script
+ * message listener. Returns the listener's tabs.sendMessage spy so the
+ * caller can verify the JSON-RPC envelope sent back to the page.
+ */
+async function dispatchDappRequest(
+  harness: ChromeHarness,
+  opts: DispatchOptions = {}
+): Promise<{ id: string; sender: { tab: { id: number }; origin: string } }> {
+  const id = opts.id ?? "rpc-1";
+  const method = opts.method ?? "stx_transferStx";
+  const params = opts.params ?? { recipient: "ST123", amount: "100" };
+  const origin = opts.origin ?? "https://app.example.com";
+  const tabId = opts.tabId ?? 42;
+
+  // Background registers two listeners; the second one (index 1) is the
+  // content-script handler that enqueues incoming dApp requests.
+  const contentListener = harness.messageListeners[1];
+  if (!contentListener) {
+    throw new Error("content-script listener not registered");
+  }
+
+  const sender = {
+    tab: { id: tabId },
+    origin,
+    id: "denvault-test",
+  };
+
+  contentListener(
+    { jsonrpc: "2.0", id, method, params },
+    sender,
+    () => undefined
+  );
+
+  // Allow microtasks (window create + sendToUI) to flush.
+  await Promise.resolve();
+  await Promise.resolve();
+
+  return { id, sender };
+}
+
+/**
+ * Simulate a popup → background message via runtime.onMessage. The popup
+ * messages are routed by the first registered listener (no sender.tab).
+ */
+function dispatchPopupMessage(
+  harness: ChromeHarness,
+  message: unknown,
+  sendResponse: (response?: unknown) => void = () => undefined
+): unknown {
+  const popupListener = harness.messageListeners[0];
+  if (!popupListener) {
+    throw new Error("popup listener not registered");
+  }
+  return popupListener(message, { id: "denvault-test" }, sendResponse);
+}
+
+describe("background queue: canonical params + explicit mismatch", () => {
+  let harness: ChromeHarness;
+
+  beforeEach(() => {
+    harness = installChromeMock();
+    loadBackground();
+  });
+
+  describe("GET_ACTIVE_REQUEST", () => {
+    it("returns canonical params for the active request", async () => {
+      await dispatchDappRequest(harness, {
+        id: "req-canonical",
+        method: "stx_transferStx",
+        params: { recipient: "ST_CANONICAL", amount: "1000000" },
+        origin: "https://canonical.example",
+      });
+
+      // UI signals ready so any pending sendToUI is flushed.
+      dispatchPopupMessage(harness, { type: "UI_READY" });
+
+      const sendResponse = vi.fn();
+      const result = dispatchPopupMessage(
+        harness,
+        { type: "GET_ACTIVE_REQUEST", requestId: "req-canonical" },
+        sendResponse
+      );
+
+      // Listener must keep channel open for async sendResponse.
+      expect(result).toBe(true);
+      expect(sendResponse).toHaveBeenCalledTimes(1);
+      const response = sendResponse.mock.calls[0][0] as {
+        ok: boolean;
+        request?: {
+          id: string;
+          method: string;
+          params: Record<string, unknown>;
+          origin: string;
+        };
+      };
+      expect(response.ok).toBe(true);
+      expect(response.request).toEqual({
+        id: "req-canonical",
+        method: "stx_transferStx",
+        params: { recipient: "ST_CANONICAL", amount: "1000000" },
+        origin: "https://canonical.example",
+      });
+    });
+
+    it("returns ok:false when there is no active request", () => {
+      const sendResponse = vi.fn();
+      dispatchPopupMessage(
+        harness,
+        { type: "GET_ACTIVE_REQUEST", requestId: "missing" },
+        sendResponse
+      );
+
+      expect(sendResponse).toHaveBeenCalledTimes(1);
+      const response = sendResponse.mock.calls[0][0] as {
+        ok: boolean;
+        error?: { code: number; message: string };
+      };
+      expect(response.ok).toBe(false);
+      expect(response.error?.code).toBe(4002);
+    });
+
+    it("returns ok:false when the requestId does not match the active one", async () => {
+      await dispatchDappRequest(harness, { id: "req-A" });
+
+      const sendResponse = vi.fn();
+      dispatchPopupMessage(
+        harness,
+        { type: "GET_ACTIVE_REQUEST", requestId: "req-DIFFERENT" },
+        sendResponse
+      );
+
+      const response = sendResponse.mock.calls[0][0] as {
+        ok: boolean;
+        error?: { code: number; message: string };
+      };
+      expect(response.ok).toBe(false);
+      expect(response.error?.code).toBe(4002);
+      expect(response.error?.message).toMatch(/expired|no longer active|mismatch/i);
+    });
+  });
+
+  describe("DAPP_APPROVE — explicit mismatch error (P1-4)", () => {
+    it("dispatches DAPP_RESPONSE_ERROR to the popup when requestId mismatches", async () => {
+      await dispatchDappRequest(harness, { id: "req-real" });
+      dispatchPopupMessage(harness, { type: "UI_READY" });
+
+      harness.runtimeSendMessage.mockClear();
+      harness.tabsSendMessage.mockClear();
+
+      dispatchPopupMessage(harness, {
+        type: "DAPP_APPROVE",
+        id: "req-WRONG",
+        result: { addresses: [] },
+      });
+
+      // Background must surface an explicit error to the popup.
+      expect(harness.runtimeSendMessage).toHaveBeenCalledTimes(1);
+      const errorMessage = harness.runtimeSendMessage.mock.calls[0][0] as {
+        type: string;
+        requestId: string;
+        error: { code: number; message: string };
+      };
+      expect(errorMessage.type).toBe("DAPP_RESPONSE_ERROR");
+      expect(errorMessage.requestId).toBe("req-WRONG");
+      expect(errorMessage.error.code).toBe(4002);
+      expect(errorMessage.error.message).toMatch(/expired|no longer active|mismatch/i);
+
+      // The dApp tab must NOT receive the popup's payload.
+      expect(harness.tabsSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("preserves the active request after a mismatched approve", async () => {
+      await dispatchDappRequest(harness, { id: "req-keep" });
+      dispatchPopupMessage(harness, { type: "UI_READY" });
+
+      dispatchPopupMessage(harness, {
+        type: "DAPP_APPROVE",
+        id: "stale-id",
+        result: { foo: "bar" },
+      });
+
+      // Active request still resolvable via canonical IPC.
+      const sendResponse = vi.fn();
+      dispatchPopupMessage(
+        harness,
+        { type: "GET_ACTIVE_REQUEST", requestId: "req-keep" },
+        sendResponse
+      );
+      const response = sendResponse.mock.calls[0][0] as { ok: boolean };
+      expect(response.ok).toBe(true);
+    });
+
+    it("forwards the result to the dApp tab when requestId matches", async () => {
+      const { sender } = await dispatchDappRequest(harness, { id: "req-good" });
+      dispatchPopupMessage(harness, { type: "UI_READY" });
+
+      harness.tabsSendMessage.mockClear();
+
+      dispatchPopupMessage(harness, {
+        type: "DAPP_APPROVE",
+        id: "req-good",
+        result: { addresses: [{ symbol: "STX", address: "ST_OK" }] },
+      });
+
+      expect(harness.tabsSendMessage).toHaveBeenCalledTimes(1);
+      const [tabId, body] = harness.tabsSendMessage.mock.calls[0];
+      expect(tabId).toBe(sender.tab.id);
+      expect(body).toMatchObject({
+        jsonrpc: "2.0",
+        id: "req-good",
+        result: { addresses: [{ symbol: "STX", address: "ST_OK" }] },
+      });
+    });
+
+    it("rejects double approve (request already resolved)", async () => {
+      await dispatchDappRequest(harness, { id: "req-once" });
+      dispatchPopupMessage(harness, { type: "UI_READY" });
+
+      // First approve consumes the request.
+      dispatchPopupMessage(harness, {
+        type: "DAPP_APPROVE",
+        id: "req-once",
+        result: { addresses: [] },
+      });
+
+      harness.runtimeSendMessage.mockClear();
+      harness.tabsSendMessage.mockClear();
+
+      // Second approve for same id should not reach the dApp tab.
+      dispatchPopupMessage(harness, {
+        type: "DAPP_APPROVE",
+        id: "req-once",
+        result: { tampered: true },
+      });
+
+      expect(harness.tabsSendMessage).not.toHaveBeenCalled();
+      // Background should explicitly tell the popup the request is gone.
+      expect(harness.runtimeSendMessage).toHaveBeenCalled();
+      const errorMessage = harness.runtimeSendMessage.mock.calls[0][0] as {
+        type: string;
+        error: { code: number };
+      };
+      expect(errorMessage.type).toBe("DAPP_RESPONSE_ERROR");
+      expect(errorMessage.error.code).toBe(4002);
+    });
+  });
+
+  describe("DAPP_REJECT — explicit mismatch error", () => {
+    it("dispatches DAPP_RESPONSE_ERROR for mismatched reject", async () => {
+      await dispatchDappRequest(harness, { id: "req-reject" });
+      dispatchPopupMessage(harness, { type: "UI_READY" });
+
+      harness.runtimeSendMessage.mockClear();
+
+      dispatchPopupMessage(harness, {
+        type: "DAPP_REJECT",
+        id: "wrong-reject",
+      });
+
+      expect(harness.runtimeSendMessage).toHaveBeenCalled();
+      const errorMessage = harness.runtimeSendMessage.mock.calls[0][0] as {
+        type: string;
+        requestId: string;
+      };
+      expect(errorMessage.type).toBe("DAPP_RESPONSE_ERROR");
+      expect(errorMessage.requestId).toBe("wrong-reject");
+    });
+
+    it("forwards rejection envelope when requestId matches", async () => {
+      const { sender } = await dispatchDappRequest(harness, { id: "req-r-good" });
+      dispatchPopupMessage(harness, { type: "UI_READY" });
+
+      harness.tabsSendMessage.mockClear();
+
+      dispatchPopupMessage(harness, {
+        type: "DAPP_REJECT",
+        id: "req-r-good",
+        error: { code: 4001, message: "User rejected the request" },
+      });
+
+      expect(harness.tabsSendMessage).toHaveBeenCalledTimes(1);
+      const [tabId, body] = harness.tabsSendMessage.mock.calls[0];
+      expect(tabId).toBe(sender.tab.id);
+      expect(body).toMatchObject({
+        jsonrpc: "2.0",
+        id: "req-r-good",
+        error: { code: 4001 },
+      });
+    });
+  });
+});

--- a/denvault-extension/src/utils/security/session.test.ts
+++ b/denvault-extension/src/utils/security/session.test.ts
@@ -268,6 +268,26 @@ describe("SessionManager", () => {
       await sessionManager.unlock("654321");
       expect(sessionManager.attemptsRemaining).toBe(1);
     });
+
+    /**
+     * Issue #18: LockoutManager zeroes its own failure count when a
+     * lockout trips, but the session mirror kept climbing. That left
+     * attemptsRemaining permanently <= 0, which the unlock screen read as
+     * "terminally disabled — reset the wallet". The gate has to be
+     * isLockedOut; the counter has to follow the lockout cycle.
+     */
+    it("resets to a full cycle once the lockout trips", async () => {
+      const encrypted = await encryptWithPIN(TEST_MNEMONIC, TEST_PIN);
+      await addWalletAsync(encrypted, "Test Wallet");
+
+      await sessionManager.unlock("654321");
+      await sessionManager.unlock("654321");
+      await sessionManager.unlock("654321");
+
+      expect(sessionManager.isLockedOut).toBe(true);
+      expect(sessionManager.attemptsRemaining).toBe(3);
+      expect(sessionManager.failedAttempts).toBe(0);
+    });
   });
 
   describe("state", () => {

--- a/denvault-extension/src/utils/security/session.ts
+++ b/denvault-extension/src/utils/security/session.ts
@@ -216,8 +216,12 @@ class SessionManager {
 
       return mnemonic;
     } catch {
-      this._failedAttempts.value++;
       this._lockout.recordFailure();
+      // Issue #18: mirror the lockout's cycle counter instead of a
+      // counter of our own. recordFailure() zeroes it when a lockout
+      // trips, so attemptsRemaining recovers with each cycle and the UI
+      // gates on isLockedOut — not on a count that never came back.
+      this._failedAttempts.value = this._lockout.failedAttempts;
 
       return null;
     }

--- a/denvault-extension/src/views/UnlockView.vue
+++ b/denvault-extension/src/views/UnlockView.vue
@@ -18,13 +18,14 @@
  * - Compact logo (40px) and title
  * - Ghost-premium keypad via PinInput
  */
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, onBeforeUnmount, computed, watch } from "vue";
 import { useRouter } from "vue-router";
 import PinScreenShell from "@/components/pin/PinScreenShell.vue";
 import PinInput from "@/components/PinInput.vue";
 import { Button } from "@/components/ui";
 import { sessionManager } from "@/utils/security/session";
 import { secureLog } from "@/utils/security/logger";
+import { useLockoutCountdown } from "@/composables/useLockoutCountdown";
 
 const router = useRouter();
 
@@ -35,7 +36,33 @@ const deleteConfirmText = ref("");
 
 const pinInputRef = ref<InstanceType<typeof PinInput> | null>(null);
 
-const attemptsRemaining = computed(() => sessionManager.attemptsRemaining);
+/**
+ * Issue #18: a temporary lockout used to read as terminal — the keypad
+ * stayed disabled and the only instruction was to reset the wallet. The
+ * countdown observes LockoutManager and releases the keypad by itself
+ * when the block expires.
+ */
+const lockout = useLockoutCountdown(sessionManager);
+
+const lockoutMessage = computed(() =>
+  lockout.isLockedOut.value
+    ? `Too many attempts. Try again in ${lockout.remainingLabel.value}.`
+    : ""
+);
+
+// The lockout notice outranks the per-attempt error while it is active.
+const displayError = computed(() => lockoutMessage.value || pinError.value);
+
+// Clear the stale "Wrong PIN" text the moment the block lifts.
+watch(
+  () => lockout.isLockedOut.value,
+  (locked, wasLocked) => {
+    if (wasLocked && !locked) {
+      pinError.value = "";
+      pinInputRef.value?.focus();
+    }
+  }
+);
 
 const canDelete = computed(() => deleteConfirmText.value.toUpperCase() === "DELETE");
 
@@ -57,16 +84,22 @@ const handleUnlock = async (pin: string) => {
     if (mnemonic) {
       secureLog("Wallet unlocked");
       router.push({ path: "/user" });
+    } else if (sessionManager.isLockedOut) {
+      // This attempt tripped the lockout: show the countdown, not a
+      // dead end. lockoutMessage takes over the error slot.
+      lockout.start();
     } else {
       const remaining = sessionManager.attemptsRemaining;
-      if (remaining <= 0) {
-        pinError.value = "Too many attempts. Reset wallet to continue.";
-      } else {
-        pinError.value = `Wrong PIN. ${remaining} attempt${remaining !== 1 ? "s" : ""} remaining.`;
-      }
+      pinError.value = `Wrong PIN. ${remaining} attempt${remaining !== 1 ? "s" : ""} remaining.`;
     }
   } catch (error) {
-    pinError.value = "Failed to unlock wallet";
+    // unlock() throws while a lockout is active; surface the countdown
+    // rather than a generic failure.
+    if (sessionManager.isLockedOut) {
+      lockout.start();
+    } else {
+      pinError.value = "Failed to unlock wallet";
+    }
     secureLog("Unlock failed", error);
   } finally {
     isLoading.value = false;
@@ -103,7 +136,15 @@ onMounted(() => {
     return;
   }
 
+  // Reopening the popup mid-lockout must show the remaining time, not a
+  // blank keypad that silently refuses input.
+  lockout.start();
+
   pinInputRef.value?.focus();
+});
+
+onBeforeUnmount(() => {
+  lockout.stop();
 });
 </script>
 
@@ -120,8 +161,8 @@ onMounted(() => {
     <PinInput
       ref="pinInputRef"
       mode="unlock"
-      :error="pinError"
-      :disabled="isLoading || attemptsRemaining <= 0"
+      :error="displayError"
+      :disabled="isLoading || lockout.isLockedOut.value"
       :show-biometric="showBiometricOption"
       hide-label
       @complete="handleUnlock"


### PR DESCRIPTION
Clears the technical path to resubmitting DenVault to the Chrome Web Store after Google rejected 1.1.0.

## What this closes

**P0-3 (red team, 2026-05-02)** — the popup could approve a request whose payload had been mutated after display, and a stale approval could hijack a different active request. Signing now sources its bytes from background's id-verified `activeRequest`, and rejects explicitly instead of warning silently. This work had been sitting uncommitted in the working tree since May.

**H1 (pre-CWS review, 2026-08-10)** — signing had moved to the canonical payload but the entire display layer still read `props.payload`, so under the exact threat the fix addresses the user would review one transaction and sign another. Display and signature now resolve from the same source.

**Issue #18** — three wrong PINs left the keypad disabled with "Too many attempts. Reset wallet to continue.", so destroying the wallet was the only way out of a 30-second block. Two defects: `session.unlock()` kept a failure counter that never recovered while `LockoutManager` zeroed its own on each trip, and nothing polled for expiry. The unlock screen now counts down live and releases the keypad by itself.

**Release plumbing** — `verify:production` only warned about `console.log` and never checked that the Hiro platform API key stayed out of the bundle. Both now fail the build. `release:zip` had 1.1.0 hardcoded, which is how a stale May artifact survived three months of changes; the version now comes from `manifest.json` and packaging refuses when `dist/` was built from a different one.

## Version

Bumped to **1.1.1**. CWS will not accept a resubmit under 1.1.0, the rejected number.

`denvault-v1.1.1.zip` (848K) was produced from a clean `verify:production`. **The stale `denvault-v1.1.0.zip` predates the red team audit and must not be uploaded.**

## Verification

- `pnpm test` — **952/952** passing, 41 files (16 new tests)
- `pnpm contract:check` — 160/160
- `pnpm type-check` — clean
- `pnpm build` — ✓
- `pnpm verify:production` — all 5 steps pass; the Hiro guard was tested in both directions
- `pnpm lint` — 7 pre-existing errors in `SendBtcView.vue` and `bitcoin/transfer.ts`, untouched by this branch

## Deferred to v1.2.0, with justification

- **P0-1** — mnemonic held as an immutable JS string rather than `SecureBuffer`, recoverable from the heap.
- **H2** — the popup still builds the signed result because the mnemonic lives in the popup session. What this PR guarantees is anti-replay and anti-stale, not end-to-end cryptographic integrity. Closing it means moving signing into the background.

Both are architectural and not suitable for a release sprint.

## Still blocking the actual submit

Google's rejection reason for 1.1.0 is not recorded anywhere in the repo — it is in the Google email or the dashboard item, citing a policy by name. Fixing internal P0s does not guarantee it addresses what Google actually objected to. The resubmit must go to the **existing item**, never a new listing.

Closes #18

Wolfcito 🐾 @akawolfcito