### PR TITLE
fix(manifest): drop unused permissions flagged by CWS review

### DIFF
--- a/denvault-extension/package.json
+++ b/denvault-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet-extension",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/denvault-extension/public/manifest.json
+++ b/denvault-extension/public/manifest.json
@@ -2,13 +2,13 @@
   "manifest_version": 3,
   "name": "DenVault",
   "short_name": "DenVault",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "DenVault - Your Bitcoin Layer 2 wallet for the Stacks ecosystem.",
   "action": {
     "default_title": "DenVault",
     "default_popup": "index.html"
   },
-  "permissions": ["storage", "tabs", "sidePanel"],
+  "permissions": ["storage", "sidePanel"],
   "side_panel": {
     "default_path": "index.html?view=sidepanel"
   },
@@ -17,8 +17,7 @@
   },
   "host_permissions": [
     "https://api.hiro.so/*",
-    "https://api.testnet.hiro.so/*",
-    "https://api.platform.hiro.so/*"
+    "https://api.testnet.hiro.so/*"
   ],
   "icons": {
     "16": "denvault-16.png",

--- a/denvault-extension/src/test/manifest-permissions.test.ts
+++ b/denvault-extension/src/test/manifest-permissions.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Manifest permission tripwire.
+ *
+ * Google rejected 1.1.0 under "Use of Permissions" (violation reference
+ * Purple Potassium): requesting a permission the extension does not use.
+ * The policy is to request only the narrowest permissions the shipped
+ * features actually need — no future-proofing.
+ *
+ * These tests pin the exact permission set so a new one cannot slip into
+ * the manifest without someone updating this file and writing down why
+ * it is needed. Each entry below must name the API that requires it.
+ */
+
+import { describe, it, expect } from "vitest";
+import manifest from "../../public/manifest.json";
+
+/**
+ * Every permission must map to an API that genuinely requires it.
+ *
+ * - storage:   chrome.storage.local / .session / .onChanged — the
+ *              encrypted vault, settings and session cache.
+ * - sidePanel: chrome.sidePanel.open + setOptions in background.js.
+ *
+ * Deliberately absent:
+ * - tabs:      chrome.tabs.create/getCurrent/query/remove/sendMessage all
+ *              work without it. The permission only gates reading
+ *              Tab.url, Tab.title, Tab.pendingUrl and Tab.favIconUrl,
+ *              none of which this extension reads.
+ * - scripting: never used; the page bridge ships through the declared
+ *              content script, not programmatic injection.
+ */
+const EXPECTED_PERMISSIONS = ["storage", "sidePanel"];
+
+/**
+ * Hosts the production bundle actually contacts.
+ *
+ * api.platform.hiro.so is deliberately absent: it is only reachable from
+ * the devnet branch in src/utils/balance/index.ts, which is dead-code
+ * eliminated when VITE_PLATFORM_HIRO_API_KEY is unset — the state
+ * verify-production.sh enforces for every release build.
+ */
+const EXPECTED_HOST_PERMISSIONS = [
+  "https://api.hiro.so/*",
+  "https://api.testnet.hiro.so/*",
+];
+
+describe("manifest permissions", () => {
+  it("requests exactly the permissions the shipped features use", () => {
+    expect(manifest.permissions).toEqual(EXPECTED_PERMISSIONS);
+  });
+
+  it("does not request the tabs permission", () => {
+    // Reading only tab.id and tab.windowId never needs it.
+    expect(manifest.permissions).not.toContain("tabs");
+  });
+
+  it("does not request the scripting permission", () => {
+    // The exact permission Google's rejection named.
+    expect(manifest.permissions).not.toContain("scripting");
+  });
+
+  it("requests exactly the hosts the production bundle contacts", () => {
+    expect(manifest.host_permissions).toEqual(EXPECTED_HOST_PERMISSIONS);
+  });
+
+  it("does not request broad host access", () => {
+    for (const host of manifest.host_permissions) {
+      expect(host).not.toBe("<all_urls>");
+      expect(host).not.toMatch(/^https:\/\/\*\/\*$/);
+      expect(host.startsWith("https://")).toBe(true);
+    }
+  });
+
+  it("keeps the content script scoped to https origins", () => {
+    for (const script of manifest.content_scripts) {
+      expect(script.matches).toEqual(["https://*/*"]);
+      expect(script.all_frames).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Addresses the Chrome Web Store rejection of 1.1.0 under **Use of Permissions** (violation reference *Purple Potassium*).

## The anomaly, stated plainly

Google's notice names `scripting` as the unused permission. **`scripting` appears in no `manifest.json` across all 463 commits of this repo, and not in the `denvault-v1.1.0.zip` artifact on disk either.** It cannot be removed because it was never declared here.

Two readings, both worth checking before resubmitting:
1. The package uploaded to the dashboard was not built from this repo's history — worth opening the **Package** tab and inspecting the manifest of the version actually under review.
2. The automated review produced a false positive, in which case the appeal form is an option.

Either way, the second half of Google's instruction — *"Audit all other permissions requested by your item"* — was actionable, and it found two real ones.

## What was actually unused

**`tabs`** — every call site works without it:

| Call | Location | Needs `tabs`? |
|---|---|---|
| `chrome.tabs.sendMessage` (7×) | background/popup bridge | no |
| `chrome.tabs.create` (2×) | — | no |
| `chrome.tabs.query` | `background.js:375`, reads `windowId` | no |
| `chrome.tabs.getCurrent` | `Confirmation.vue:265`, reads `id` | no |
| `chrome.tabs.remove` | `Confirmation.vue:267` | no |

The permission only gates `Tab.url`, `Tab.title`, `Tab.pendingUrl` and `Tab.favIconUrl`. Nothing in the extension reads any of them — verified by grep across `src/` and `public/`.

**`https://api.platform.hiro.so/*`** — only reachable from the devnet branch in `src/utils/balance/index.ts:27`. That branch is dead-code eliminated when `VITE_PLATFORM_HIRO_API_KEY` is unset, which is the state `verify-production.sh` step 5 now enforces for every release build. The shipped bundle never contacts that host, so declaring it is exactly the "future proofing" the policy prohibits.

Resulting manifest:

```json
"permissions": ["storage", "sidePanel"],
"host_permissions": [
  "https://api.hiro.so/*",
  "https://api.testnet.hiro.so/*"
]
```

`storage` backs the encrypted vault, settings and session cache (69 call sites). `sidePanel` backs `chrome.sidePanel.open` and `setOptions` in `background.js`.

## Preventing the regression

`src/test/manifest-permissions.test.ts` pins the permission and host lists and asserts the absence of `tabs` and `scripting` by name. Adding a permission now requires updating that file, where each entry has to name the API that requires it. It also guards against `<all_urls>`, broad `https://*/*` host access, and content-script scope creep.

## Cost of the host permission removal

Devnet development against `api.platform.hiro.so` now needs the host re-added to a local manifest. Accepted deliberately: the CWS package must carry only what it uses.

## Verification

- `pnpm test` — **958/958** passing, 42 files (6 new)
- `pnpm contract:check` — 160/160
- `pnpm type-check` — clean
- `pnpm verify:production` — all 5 steps pass
- `denvault-v1.1.2.zip` (852K) packaged from that clean run

## Before resubmitting

- Upload to the **existing item** `npojbdkhjpgfkfjeagfcfhjchcnpkfek`, never a new listing.
- The listing's Homepage and Support URLs still point at `wolfcito.github.io/stack-sats/`, but the GitHub account was renamed to `akawolfcito`. Those redirects are outside our control and break outright if the old handle is ever reclaimed.

Wolfcito 🐾 @akawolfcito