### PR TITLE
test(e2e): run a smoke suite against the real loaded extension

### DIFF
--- a/denvault-extension/e2e/extension/fixtures.ts
+++ b/denvault-extension/e2e/extension/fixtures.ts
@@ -1,0 +1,82 @@
+/**
+ * Fixtures that load the real built extension.
+ *
+ * Every other spec in e2e/ runs against the Vite dev server as an ordinary
+ * page with a mocked `chrome.*` — which means background.js never runs as
+ * a service worker and the content-script bridge is never exercised. These
+ * fixtures close that gap: Chromium boots with `dist/` loaded, so the
+ * tests see the actual worker, the actual injected page API, and the
+ * actual popup.
+ *
+ * Requires a build first — `pnpm test:e2e:extension` does it for you.
+ */
+
+import { test as base, chromium, type BrowserContext, type Worker } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXTENSION_PATH = path.join(__dirname, "../../dist");
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+  serviceWorker: Worker;
+}>({
+  context: async ({}, use) => {
+    const context = await chromium.launchPersistentContext("", {
+      // The chromium channel is what lets extensions run headless.
+      channel: "chromium",
+      args: [
+        `--disable-extensions-except=${EXTENSION_PATH}`,
+        `--load-extension=${EXTENSION_PATH}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+
+  serviceWorker: async ({ context }, use) => {
+    let [worker] = context.serviceWorkers();
+    if (!worker) {
+      worker = await context.waitForEvent("serviceworker");
+    }
+    await use(worker);
+  },
+
+  extensionId: async ({ serviceWorker }, use) => {
+    // chrome-extension://<id>/background.js
+    await use(serviceWorker.url().split("/")[2]);
+  },
+});
+
+export const expect = test.expect;
+
+/**
+ * Serve a fake dApp over https.
+ *
+ * The content script matches `https://*\/*`, so an http://localhost page
+ * would never get the bridge injected. Fulfilling an https URL keeps the
+ * match while staying offline.
+ */
+export async function openDapp(context: BrowserContext, origin = "https://dapp.test") {
+  const page = await context.newPage();
+  await page.route(`${origin}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!DOCTYPE html><html><body><h1>Test dApp</h1></body></html>",
+    })
+  );
+  await page.goto(`${origin}/`);
+
+  // content.js injects injection.js as a module script, which resolves
+  // asynchronously — reading window.StacksWallet right after goto races it.
+  await page.waitForFunction(
+    () => Boolean((window as unknown as { StacksWallet?: unknown }).StacksWallet),
+    undefined,
+    { timeout: 15000 }
+  );
+
+  return page;
+}

--- a/denvault-extension/e2e/extension/smoke.spec.ts
+++ b/denvault-extension/e2e/extension/smoke.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Smoke test against the real loaded extension.
+ *
+ * Covers the surfaces nothing else does — the service worker, the
+ * content-script bridge and the packaged popup — focused on what the
+ * 1.1.3 changes touched.
+ */
+
+import { test, expect, openDapp } from "./fixtures";
+
+test("the service worker boots and reports the packaged version", async ({
+  serviceWorker,
+}) => {
+  const manifest = await serviceWorker.evaluate(() => chrome.runtime.getManifest());
+
+  expect(manifest.version).toBe("1.1.3");
+  expect(manifest.permissions).toEqual(["storage", "sidePanel"]);
+  expect(manifest.host_permissions).toEqual([
+    "https://api.hiro.so/*",
+    "https://api.testnet.hiro.so/*",
+  ]);
+});
+
+test("the popup loads from the packaged build", async ({ context, extensionId }) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+
+  // Onboarding is the first screen with no wallet in storage.
+  await expect(page.locator("body")).toContainText(/wallet/i, { timeout: 15000 });
+
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.waitForTimeout(1000);
+  expect(errors).toEqual([]);
+});
+
+test("the page API advertises exactly the implemented methods", async ({ context }) => {
+  const page = await openDapp(context);
+
+  // The advertised list reaches dApps through the WBIP004 provider
+  // registration, not as a property of window.StacksWallet.
+  const provider = await page.evaluate(
+    () =>
+      (window as unknown as { wbip_providers?: Array<{ id: string; methods: string[] }> })
+        .wbip_providers?.find((p) => p.id === "DenVault")
+  );
+
+  expect(provider).toBeTruthy();
+  expect(provider!.methods).toEqual([
+    "getAddresses",
+    "stx_signMessage",
+    "stx_transferStx",
+    "stx_signStructuredMessage",
+    "stx_getAddresses",
+    "stx_deployContract",
+    "stx_callContract",
+  ]);
+});
+
+test("a withdrawn method is refused by the page API without reaching the wallet", async ({
+  context,
+}) => {
+  const page = await openDapp(context);
+
+  // request() rejects with the JSON-RPC envelope rather than resolving.
+  const result = await page.evaluate(async () => {
+    const wallet = (
+      window as unknown as {
+        StacksWallet: { request: (m: string, p: unknown) => Promise<unknown> };
+      }
+    ).StacksWallet;
+    try {
+      return { resolved: await wallet.request("signPsbt", {}) };
+    } catch (rejection) {
+      return rejection as { error?: { code: number } };
+    }
+  });
+
+  expect(result).toMatchObject({ error: { code: -32601 } });
+  // No approval window was opened: only the dApp tab exists.
+  expect(context.pages().filter((p) => p.url().startsWith("chrome-extension://"))).toHaveLength(0);
+});
+
+test("the background refuses a withdrawn method dispatched straight at the bridge", async ({
+  context,
+}) => {
+  const page = await openDapp(context);
+
+  // Bypasses injection.js entirely: content.js relays any well-formed
+  // event, which is why the real guard has to live in the background.
+  const response = await page.evaluate(async () => {
+    return new Promise((resolve) => {
+      window.addEventListener("message", (event) => {
+        const data = event.data as { jsonrpc?: string; error?: { code: number } };
+        if (data?.jsonrpc === "2.0" && data.error) resolve(data);
+      });
+      document.dispatchEvent(
+        new CustomEvent("stackswallet_request", {
+          detail: { jsonrpc: "2.0", id: "raw-1", method: "signPsbt", params: {} },
+        })
+      );
+      setTimeout(() => resolve({ timedOut: true }), 8000);
+    });
+  });
+
+  expect(response).toMatchObject({ error: { code: -32601 } });
+  expect(context.pages().filter((p) => p.url().startsWith("chrome-extension://"))).toHaveLength(0);
+});

--- a/denvault-extension/package.json
+++ b/denvault-extension/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
+    "test:e2e:extension": "pnpm build-only && playwright test --project=extension",
     "ui:snapshots": "VITE_UI_SNAPSHOT=1 playwright test golden-screenshots --project=chromium",
     "ui:shots": "VITE_UI_SNAPSHOT=1 playwright test golden-matrix --project=chromium",
     "ui:roi": "VITE_UI_SNAPSHOT=1 playwright test golden-roi --project=chromium",

--- a/denvault-extension/playwright.config.ts
+++ b/denvault-extension/playwright.config.ts
@@ -25,7 +25,20 @@ export default defineConfig({
 
   projects: [
     {
+      /**
+       * Loads the real built extension from dist/, so the service worker,
+       * the content-script bridge and the packaged popup are exercised for
+       * real. Every other project runs against the dev server with a
+       * mocked chrome.*, which cannot see any of that.
+       *
+       * Needs a build: use `pnpm test:e2e:extension`.
+       */
+      name: 'extension',
+      testMatch: /e2e[\\/]extension[\\/].*\.spec\.ts/,
+    },
+    {
       name: 'chromium',
+      testIgnore: /e2e[\\/]extension[\\/].*\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 400, height: 600 }, // Popup size
@@ -33,6 +46,7 @@ export default defineConfig({
     },
     {
       name: 'chromium-sidepanel',
+      testIgnore: /e2e[\\/]extension[\\/].*\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 400, height: 800 }, // Sidepanel size

--- a/denvault-extension/public/background.js
+++ b/denvault-extension/public/background.js
@@ -588,14 +588,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // that cannot complete.
   const method = message.method;
   if (!ACCEPTED_METHODS.includes(method)) {
-    sendResponse({
+    const notSupported = {
       jsonrpc: "2.0",
       id: message.id,
       error: {
         code: -32601,
         message: `Method ${method} is not supported`,
       },
-    });
+    };
+    // content.js forwards page requests with a bare sendMessage and no
+    // callback, so sendResponse alone would be dropped. The page channel
+    // is chrome.tabs.sendMessage — the same one successful responses use.
+    chrome.tabs.sendMessage(sender.tab.id, notSupported).catch(() => {});
+    sendResponse(notSupported);
     return;
   }
 

--- a/denvault-extension/public/injection.js
+++ b/denvault-extension/public/injection.js
@@ -9,8 +9,9 @@ const REQUEST_TIMEOUT_MS = 60000; // 60 seconds
 /**
  * Methods the wallet can actually carry to a signed result.
  *
- * This list is published to every page as `window.StacksWallet.methods`,
- * so it is a promise to dApps. Only add a method once a handler exists —
+ * Published to every page through the WBIP004 provider registration
+ * (`window.wbip_providers`), so it is a promise to dApps, and enforced
+ * here in `request()`. Only add a method once a handler exists —
  * advertising one without an implementation produced an approval screen
  * that asked for the PIN and then failed with -32603.
  */

--- a/denvault-extension/src/test/rpc-method-contract.test.ts
+++ b/denvault-extension/src/test/rpc-method-contract.test.ts
@@ -1,9 +1,10 @@
 /**
  * RPC surface contract.
  *
- * `public/injection.js` publishes SUPPORTED_METHODS to every page as
- * `window.StacksWallet.methods`. That list is a promise: a dApp that sees
- * a method there expects the wallet to be able to complete it.
+ * `public/injection.js` publishes SUPPORTED_METHODS to every page through
+ * the WBIP004 provider registration (`window.wbip_providers`), and gates
+ * `request()` on it. That list is a promise: a dApp that sees a method
+ * there expects the wallet to be able to complete it.
  *
  * It used to advertise four methods that fell through to `// TODO:
  * implement` in Confirmation.handleConfirm. The user got a polished


### PR DESCRIPTION
Every existing e2e spec runs against the Vite dev server as an ordinary page with a mocked `chrome.*`. The repo says so itself:

> `playwright.config.ts`: *"For extension testing, we use the dev server and navigate to the extension popup/sidepanel URLs"*
> `dapp-rpc.spec.ts`: *"The dev server has no extension runtime, so we emulate it"* … *"Queue mode and full content-script integration are intentionally out of scope"*

Zero occurrences of `--load-extension`, `launchPersistentContext` or `chrome-extension://` anywhere in `e2e/`. So `background.js` had never run as a real service worker and the content-script bridge had never been exercised — the exact surfaces the 1.1.3 changes touched.

## What this adds

An `extension` Playwright project that boots Chromium with `dist/` loaded (`channel: 'chromium'` runs extensions headless). Five checks:

1. the service worker boots and reports the packaged manifest — version, permissions, host permissions
2. the popup loads from `chrome-extension://<id>/index.html` with no page errors
3. the advertised method list matches the seven implemented ones
4. a withdrawn method is refused by the page API, with no approval window
5. a withdrawn method **dispatched straight at the content-script bridge**, bypassing `injection.js`, is refused by the background — no approval window

Run with `pnpm test:e2e:extension`.

## What it found

**The `-32601` never reached the page.** `content.js` forwards page requests with a bare `chrome.runtime.sendMessage` and no callback, so the `sendResponse` I added in #30 was dropped on the floor. The security goal held — no popup, no PIN prompt — but the dApp got silence instead of an error. It now also replies over `chrome.tabs.sendMessage`, the channel successful responses already use. The pre-existing origin-not-allowed and rate-limit rejections have the same shape; left alone here rather than widening the change.

**My own claim was wrong.** #30 said `SUPPORTED_METHODS` is published as `window.StacksWallet.methods`. It isn't — that property does not exist. The list reaches dApps through the WBIP004 provider registration (`window.wbip_providers`) and gates `request()`. Comments in `injection.js` and `rpc-method-contract.test.ts` corrected.

**The project filter matched everything.** A naive `extension/` pattern matched all 263 specs, because the repo directory is itself named `denvault-extension`. Anchored to `e2e/extension/`. Counts verified: 5 extension, 258 chromium, 258 chromium-sidepanel.

## Scope

Deliberately a smoke suite, not full coverage. Creating a wallet, the PIN lockout countdown and an end-to-end dApp approval are all reachable from here now, but each needs onboarding drive-through and network mocking — worth doing as its own piece rather than bolted on.

## Verification

- `pnpm test` — 997/997 unit
- `pnpm test:e2e:extension` — 5/5 against the real extension
- `pnpm lint` — clean · `contract:check` — 160/160 · `type-check` — clean
- `verify:production` — all 5 steps · `denvault-v1.1.3.zip` repackaged

Wolfcito 🐾 @akawolfcito